### PR TITLE
Better Handling of Multidev Branch Naming to Handle Multiple Underscores

### DIFF
--- a/example.circle.yml
+++ b/example.circle.yml
@@ -25,7 +25,7 @@ machine:
     BRANCH: $(echo $CIRCLE_BRANCH | grep -v '^\(master\|[0-9]\+.x\)$')
     PR_ENV: ${BRANCH:+pr-$BRANCH}
     CIRCLE_ENV: ci-$CIRCLE_BUILD_NUM
-    DEFAULT_ENV: $(echo ${PR_ENV:-$CIRCLE_ENV} | cut -c -11 | sed 's/-$//')
+    DEFAULT_ENV: $(echo ${PR_ENV:-$CIRCLE_ENV} | cut -c -11 | sed 's/_/-/g' | sed 's/-$//')
     TERMINUS_ENV: ${TERMINUS_ENV:-$DEFAULT_ENV}
     NOTIFY: 'scripts/github/add-commit-comment {project} {sha} "Created multidev environment [{site}#{env}]({dashboard-url})." {site-url}'
     PATH: $PATH:~/.composer/vendor/bin:~/.config/composer/vendor/bin:tests/scripts


### PR DESCRIPTION
There is a problem with the existing logic in creating Multidev branch naming that in cases where there are multiple underscores they don't properly get filtered into Multidev acceptable naming. FOr example:

underscore_name_fix
update_local_dev_readme

The updated replacement logic will filter out cases like these.