### PR TITLE
Use a consistent System-Under-Test

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,7 @@ machine:
     TERMINUS_SITE: build-tools-$CIRCLE_BUILD_NUM
     TERMINUS_ORG: CI for Drupal 8 + Composer
     GITHUB_USERNAME: pantheon-ci-bot
-    SOURCE_COMPOSER_PROJECT: pantheon-systems/example-drops-8-composer
+    SOURCE_COMPOSER_PROJECT: pantheon-systems/example-drops-8-composer:dev-test
     TARGET_REPO: $GITHUB_USERNAME/$TERMINUS_SITE
     TARGET_REPO_WORKING_COPY: $HOME/$TERMINUS_SITE
     PATH: $PATH:~/.composer/vendor/bin:~/.config/composer/vendor/bin
@@ -38,7 +38,8 @@ dependencies:
     - composer global require -n "consolidation/cgr"
     - cgr "pantheon-systems/terminus:~1" --stability beta
     - terminus --version
-    # Link the project directory as a Terminus plugin.
+    # Install the copy of the Build Tools Plugin cloned by CircleCI as a plugin
+    # in Terminus, so that all build-env commands run the System-Under-Test.
     - mkdir -p $HOME/.terminus/plugins
     - ln -s $(pwd) $HOME/.terminus/plugins
     - terminus list -n build-env
@@ -46,7 +47,10 @@ dependencies:
     - terminus auth:login -n --machine-token="$TERMINUS_TOKEN"
 test:
   override:
-    - terminus build-env:create-project -n "$SOURCE_COMPOSER_PROJECT" "$TERMINUS_SITE" --team="$TERMINUS_ORG" --email="$GIT_EMAIL"
+    # Clone from the `test` branch of pantheon-systems/example-drops-8-composer.
+    # Tell that project to install dev-$CIRCLE_BRANCH of the Build Tools Plugin
+    # so that we are running the same System-Under-Test in both places.
+    - terminus build-env:create-project -n "$SOURCE_COMPOSER_PROJECT" "$TERMINUS_SITE" --team="$TERMINUS_ORG" --email="$GIT_EMAIL" --env="BUILD_TOOLS_VERSION=dev-$CIRCLE_BRANCH"
     # Confirm that the Pantheon site was created
     - terminus site:info "$TERMINUS_SITE"
     # Confirm that the Github project was created

--- a/src/Commands/BuildToolsCommand.php
+++ b/src/Commands/BuildToolsCommand.php
@@ -178,6 +178,7 @@ class BuildToolsCommand extends TerminusCommand implements SiteAwareInterface
             'admin-password' => '',
             'admin-email' => '',
             'stability' => '',
+            'env' => [],
         ])
     {
         $this->warnAboutOldPhp();
@@ -363,10 +364,19 @@ class BuildToolsCommand extends TerminusCommand implements SiteAwareInterface
     {
         $site = $this->getSite($site_name);
 
+        $options += [
+            'test-site-name' => '',
+            'email' => '',
+            'admin-password' => '',
+            'admin-email' => '',
+            'env' => [],
+        ];
+
         $test_site_name = $options['test-site-name'];
         $git_email = $options['email'];
         $admin_password = $options['admin-password'];
         $admin_email = $options['admin-email'];
+        $extra_env = $options['env'];
 
         if (empty($test_site_name)) {
             $test_site_name = $site_name;
@@ -398,6 +408,15 @@ class BuildToolsCommand extends TerminusCommand implements SiteAwareInterface
         $github_token = getenv('GITHUB_TOKEN');
         if ($github_token) {
             $circle_env['GITHUB_TOKEN'] = $github_token;
+        }
+
+        // Add in extra environment provided on command line via
+        // --env='key=value' --env='another=v2'
+        foreach ($extra_env as $env) {
+            list($key, $value) = explode('=', $env, 2) + ['',''];
+            if (!empty($key) && !empty($value)) {
+                $circle_env[$key] = $value;
+            }
         }
 
         return $circle_env;
@@ -490,6 +509,7 @@ class BuildToolsCommand extends TerminusCommand implements SiteAwareInterface
             'email' => '',
             'admin-password' => '',
             'admin-email' => '',
+            'env' => [],
         ])
     {
         $site = $this->getSite($site_name);


### PR DESCRIPTION
Ensure we are using a consistent version of the Terminus Build Tools plugin, so that we do not vary the System-Under-Test in the derived project we create.