### PR TITLE
WIP - Support for WordPress example repo

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,7 @@ machine:
     TERMINUS_SITE: build-tools-$CIRCLE_BUILD_NUM
     TERMINUS_ORG: CI for Drupal 8 + Composer
     GITHUB_USERNAME: pantheon-ci-bot
-    SOURCE_COMPOSER_PROJECT: pantheon-systems/example-drops-8-composer:dev-test
+    SOURCE_COMPOSER_PROJECT: stevector/example-wordpress-composer:dev-wordpress-build-plugin
     TARGET_REPO: $GITHUB_USERNAME/$TERMINUS_SITE
     TARGET_REPO_WORKING_COPY: $HOME/$TERMINUS_SITE
     BRANCH: $(echo $CIRCLE_BRANCH | grep -v '^\(master\|[0-9]\+.x\)$')

--- a/src/Commands/BuildToolsCommand.php
+++ b/src/Commands/BuildToolsCommand.php
@@ -659,7 +659,7 @@ class BuildToolsCommand extends TerminusCommand implements SiteAwareInterface
      */
     protected function autodetectUpstream($siteDir)
     {
-        if (file_exists($siteDir . 'wp-cli.yml')) {
+        if (file_exists($siteDir . '/wp-cli.yml')) {
             return 'WordPress';
         }
         else {

--- a/src/Commands/BuildToolsCommand.php
+++ b/src/Commands/BuildToolsCommand.php
@@ -379,6 +379,7 @@ class BuildToolsCommand extends TerminusCommand implements SiteAwareInterface
                 'account-pass' => $circle_env['ADMIN_PASSWORD'],
                 'site-mail' => $circle_env['ADMIN_EMAIL'],
                 'site-name' => $circle_env['TEST_SITE_NAME'],
+                'site-url' => "https://dev-{$site_name}.pantheonsite.io"
             ];
             $this->doInstallSite("{$site_name}.dev", $composer_json, $site_install_options);
 
@@ -394,11 +395,11 @@ class BuildToolsCommand extends TerminusCommand implements SiteAwareInterface
             $this->configureCircle($target_project, $circle_token, $circle_env);
         }
         catch (\Exception $e) {
-            $ch = $this->createGitHubDeleteChannel("repos/$target_project", $github_token);
-            $data = $this->execCurlRequest($ch, 'GitHub');
-            if (isset($site)) {
-                $site->delete();
-            }
+//            $ch = $this->createGitHubDeleteChannel("repos/$target_project", $github_token);
+//            $data = $this->execCurlRequest($ch, 'GitHub');
+//            if (isset($site)) {
+//                $site->delete();
+//            }
             throw $e;
         }
         $this->log()->notice('Your new site repository is {github}', ['github' => "https://github.com/$target_project"]);
@@ -486,6 +487,9 @@ class BuildToolsCommand extends TerminusCommand implements SiteAwareInterface
             'TEST_SITE_NAME' => $test_site_name,
             'ADMIN_PASSWORD' => $admin_password,
             'ADMIN_EMAIL' => $admin_email,
+            'WORDPRESS_ADMIN_PASSWORD' => $admin_password,
+          'WORDPRESS_ADMIN_USERNAME' => 'admin',
+
             'GIT_EMAIL' => $git_email,
         ];
         // If this site cannot create multidev environments, then configure
@@ -658,6 +662,7 @@ class BuildToolsCommand extends TerminusCommand implements SiteAwareInterface
      */
     protected function autodetectUpstream($siteDir)
     {
+        return 'WordPress';
         return 'Empty Upstream';
         // or 'Drupal 7' or 'WordPress'
         // return 'Drupal 8';

--- a/src/Commands/BuildToolsCommand.php
+++ b/src/Commands/BuildToolsCommand.php
@@ -659,11 +659,11 @@ class BuildToolsCommand extends TerminusCommand implements SiteAwareInterface
      */
     protected function autodetectUpstream($siteDir)
     {
-        if (file_exists($siteDir . '/wp-cli.yml')) {
+        if (file_exists($siteDir . '/web/wp-config.php')) {
             return 'WordPress';
         }
         else {
-            // This upstream works for Drupal 8 and Drupal 7.
+            // This upstream works for Drupal 8.
             return 'Empty Upstream';
         }
     }

--- a/src/Commands/BuildToolsCommand.php
+++ b/src/Commands/BuildToolsCommand.php
@@ -395,11 +395,11 @@ class BuildToolsCommand extends TerminusCommand implements SiteAwareInterface
             $this->configureCircle($target_project, $circle_token, $circle_env);
         }
         catch (\Exception $e) {
-//            $ch = $this->createGitHubDeleteChannel("repos/$target_project", $github_token);
-//            $data = $this->execCurlRequest($ch, 'GitHub');
-//            if (isset($site)) {
-//                $site->delete();
-//            }
+            $ch = $this->createGitHubDeleteChannel("repos/$target_project", $github_token);
+            $data = $this->execCurlRequest($ch, 'GitHub');
+            if (isset($site)) {
+                $site->delete();
+            }
             throw $e;
         }
         $this->log()->notice('Your new site repository is {github}', ['github' => "https://github.com/$target_project"]);
@@ -487,9 +487,6 @@ class BuildToolsCommand extends TerminusCommand implements SiteAwareInterface
             'TEST_SITE_NAME' => $test_site_name,
             'ADMIN_PASSWORD' => $admin_password,
             'ADMIN_EMAIL' => $admin_email,
-            'WORDPRESS_ADMIN_PASSWORD' => $admin_password,
-          'WORDPRESS_ADMIN_USERNAME' => 'admin',
-
             'GIT_EMAIL' => $git_email,
         ];
         // If this site cannot create multidev environments, then configure
@@ -662,10 +659,13 @@ class BuildToolsCommand extends TerminusCommand implements SiteAwareInterface
      */
     protected function autodetectUpstream($siteDir)
     {
-        return 'WordPress';
-        return 'Empty Upstream';
-        // or 'Drupal 7' or 'WordPress'
-        // return 'Drupal 8';
+        if (file_exists($siteDir . 'wp-cli.yml')) {
+            return 'WordPress';
+        }
+        else {
+            // This upstream works for Drupal 8 and Drupal 7.
+            return 'Empty Upstream';
+        }
     }
 
     /**


### PR DESCRIPTION
Here is a work-in-progress PR to replace https://github.com/pantheon-systems/terminus-build-tools-plugin/pull/9

This PR should not be merged until

- [ ] There's a mechanism in place for running CI against multiple values of `SOURCE_COMPOSER_PROJECT` (My thought is to use a matrix of variable in Travis). Related to https://github.com/pantheon-systems/terminus-build-tools-plugin/issues/5
- [ ] The substance of this PR itself is reviewed (I'm greatly encouraged by how small this PR is)
- [ ] The WordPress example repo is moved from `stevector/example-wordpress-composer` to `pantheon-systems/example-wordpress-composer`, [a task which has its own set of issues](https://github.com/stevector/example-wordpress-composer/issues?q=is%3Aissue+is%3Aopen+label%3ABlocks-move-to-pantheon-systems).