### PR TITLE
fixes syntax error in ProjectCreateCommand

### DIFF
--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -284,7 +284,6 @@ class ProjectCreateCommand extends BuildToolsBase implements PublicKeyReciever
                             $this->log()->notice('Building assets for project');
                             $this->passthru("composer -d $siteDir build-assets");
                         }
-                    }
                 );
         }
 


### PR DESCRIPTION
Updates https://github.com/pantheon-systems/terminus-build-tools-plugin/pull/37 for syntax error, failing build.