### PR TITLE
Checkout Pantheon's master branch rather than source master

### DIFF
--- a/src/Commands/BuildToolsCommand.php
+++ b/src/Commands/BuildToolsCommand.php
@@ -1370,7 +1370,8 @@ class BuildToolsCommand extends TerminusCommand implements SiteAwareInterface
         // Checkout Pantheon's master branch. Use excessively long branch name
         // because "master" as a branch name is likely ambiguous as it can exist
         // on both Pantheon and the source repo
-        $this->passthru('git checkout -b temp-local-copy-of-pantheon-master remote/pantheon/master');
+        $this->passthru('git fetch pantheon');
+        $this->passthru('git checkout -B temp-local-copy-of-pantheon-master remote/pantheon/master');
         // Replace the entire contents of the master branch with the branch we just tested.
         $this->passthru("git merge -q -m 'Merge build assets from test $env_label.' -X theirs $env_id");
 

--- a/src/Commands/BuildToolsCommand.php
+++ b/src/Commands/BuildToolsCommand.php
@@ -1367,12 +1367,15 @@ class BuildToolsCommand extends TerminusCommand implements SiteAwareInterface
         $dev_env = $site->getEnvironments()->get('dev');
         $this->connectionSet($dev_env, 'git');
 
+        // Checkout Pantheon's master branch. Use excessively long branch name
+        // because "master" as a branch name is likely ambiguous as it can exist
+        // on both Pantheon and the source repo
+        $this->passthru('git checkout -b temp-local-copy-of-pantheon-master remote/pantheon/master');
         // Replace the entire contents of the master branch with the branch we just tested.
-        $this->passthru('git checkout master');
         $this->passthru("git merge -q -m 'Merge build assets from test $env_label.' -X theirs $env_id");
 
         // Push our changes back to the dev environment, replacing whatever was there before.
-        $this->passthru('git push --force -q pantheon master');
+        $this->passthru('git push --force -q pantheon temp-local-copy-of-pantheon-master:master');
 
         // Wait for the dev environment to finish syncing after the merge.
         $this->waitForCodeSync($preCommitTime, $site, 'dev');

--- a/src/Commands/BuildToolsCommand.php
+++ b/src/Commands/BuildToolsCommand.php
@@ -1371,7 +1371,8 @@ class BuildToolsCommand extends TerminusCommand implements SiteAwareInterface
         // because "master" as a branch name is likely ambiguous as it can exist
         // on both Pantheon and the source repo
         $this->passthru('git fetch pantheon');
-        $this->passthru('git checkout -B temp-local-copy-of-pantheon-master remote/pantheon/master');
+        $this->passthru('git checkout remote/pantheon/master');
+        $this->passthru('git checkout -B temp-local-copy-of-pantheon-master');
         // Replace the entire contents of the master branch with the branch we just tested.
         $this->passthru("git merge -q -m 'Merge build assets from test $env_label.' -X theirs $env_id");
 

--- a/src/Commands/BuildToolsCommand.php
+++ b/src/Commands/BuildToolsCommand.php
@@ -1371,7 +1371,7 @@ class BuildToolsCommand extends TerminusCommand implements SiteAwareInterface
         // because "master" as a branch name is likely ambiguous as it can exist
         // on both Pantheon and the source repo
         $this->passthru('git fetch pantheon');
-        $this->passthru('git checkout remote/pantheon/master');
+        $this->passthru('git checkout pantheon/master');
         $this->passthru('git checkout -B temp-local-copy-of-pantheon-master');
         // Replace the entire contents of the master branch with the branch we just tested.
         $this->passthru("git merge -q -m 'Merge build assets from test $env_label.' -X theirs $env_id");


### PR DESCRIPTION
This PR is meant to solve: https://github.com/pantheon-systems/terminus-build-tools-plugin/issues/58

@greg-1-anderson If the `temp-local-copy-of-pantheon-master` branch is deleted after the push, what would be the branch to checkout instead?