### PR TITLE
Allow empty configuration after initial profile install. If a profile…

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -49,6 +49,12 @@ dependencies:
     - terminus list -n build
   post:
     - terminus auth:login -n --machine-token="$TERMINUS_TOKEN"
+    # Clean up old ssh keys
+    - |
+      for key in $(terminus ssh-key:list --fields=Description,ID | grep ci-bot-build-tools | sort -r | sed -e '1,3d' | sed -e 's/ *[^ ]* *//') ; do
+        terminus ssh-key:remove $key
+      done
+
 test:
   override:
     # Clone from the `test` branch of pantheon-systems/example-drops-8-composer.

--- a/circle.yml
+++ b/circle.yml
@@ -50,10 +50,7 @@ dependencies:
   post:
     - terminus auth:login -n --machine-token="$TERMINUS_TOKEN"
     # Clean up old ssh keys
-    - |
-      for key in $(terminus ssh-key:list --fields=Description,ID | grep ci-bot-build-tools | sort -r | sed -e '1,3d' | sed -e 's/ *[^ ]* *//') ; do
-        terminus ssh-key:remove $key
-      done
+    - for key in $(terminus ssh-key:list --fields=Description,ID 2>/dev/null | grep ci-bot-build-tools | sort -r | sed -e '1,3d' | sed -e 's/ *[^ ]* *//') ; do terminus ssh-key:remove $key ; done
 
 test:
   override:

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -593,7 +593,10 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         $this->rsync($site_env_id, ':code/config', $repositoryDir);
 
         $this->passthru("git -C $repositoryDir add config");
-        $this->passthru("git -C $repositoryDir commit -m 'Export configuration'");
+        exec("git -C $repositoryDir status --porcelain", $outputLines, $status);
+        if (!empty($outputLines)) {
+            $this->passthru("git -C $repositoryDir commit -m 'Export configuration'");
+        }
     }
 
     /**


### PR DESCRIPTION
… installs its configuration from exported .yml files, then there will be nothing to export during the installation step.