### PR TITLE
WordPress install fix

### DIFF
--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -412,6 +412,7 @@ class ProjectCreateCommand extends BuildToolsBase implements PublicKeyReciever
                         'account-pass' => $siteAttributes->adminPassword(),
                         'site-mail' => $siteAttributes->adminEmail(),
                         'site-name' => $siteAttributes->testSiteName(),
+                        'site-url' => "https://dev-{$site_name}.pantheonsite.io"
                     ];
                     $this->doInstallSite("{$site_name}.dev", $composer_json, $site_install_options);
 


### PR DESCRIPTION
PR https://github.com/pantheon-systems/terminus-build-tools-plugin/pull/60 is meant to add testing support for a WordPress repo. It is currently failing because of problems switching the Drupal test to Circle 2. I'd like to get that problem resolved today. But I also want to unblock the WordPress functionality change itself. And that is very small, this one line.

@greg-1-anderson do you think we can merge this change independent of https://github.com/pantheon-systems/terminus-build-tools-plugin/pull/60