### PR TITLE
Fix sha hash used in commit comments.

### DIFF
--- a/src/Commands/CommentAddCommitCommand.php
+++ b/src/Commands/CommentAddCommitCommand.php
@@ -24,17 +24,21 @@ class CommentAddCommitCommand extends BuildToolsBase
      */
     public function commentAddCommit(
         $options = [
+            'sha' => '',
             'message' => '',
             'site_url' => ''
         ])
     {
         // Get current repository and commit
         $remoteUrlFromGit = exec('git config --get remote.origin.url');
-        $commitHash = exec('git rev-parse HEAD');
+        $commitHash = $options['sha'];
+        if (empty($commitHash)) {
+            $commitHash = exec('git rev-parse HEAD');
+        }
 
         // Create a Git repository service provider appropriate to the URL
         $this->inferGitProviderFromUrl($remoteUrlFromGit);
-        
+
         // Ensure that credentials for the Git provider are available
         $this->providerManager()->validateCredentials();
 
@@ -46,7 +50,7 @@ class CommentAddCommitCommand extends BuildToolsBase
         }
 
         if (!empty($message)) {
-            // Submit message 
+            // Submit message
             $targetProject = $this->projectFromRemoteUrl($remoteUrlFromGit);
             $this->git_provider->commentOnCommit($targetProject, $commitHash, $message);
         }

--- a/src/Commands/EnvCreateCommand.php
+++ b/src/Commands/EnvCreateCommand.php
@@ -144,7 +144,7 @@ class EnvCreateCommand extends BuildToolsBase
                 'message' => "Created multidev environment [{$multidev}]({$dashboard_url}) for {$site_name}."
             ];
 
-            $command = $this->interpolate('terminus build:comment:add:commit --sha [[sha]] --message [[label]] --site_url "[[site-url]]"', $metadata);
+            $command = $this->interpolate('terminus build:comment:add:commit --sha [[sha]] --message [[message]] --site_url [[site-url]]', $metadata);
 
             // Run notification command. Ignore errors.
             passthru($command);

--- a/src/Commands/EnvCreateCommand.php
+++ b/src/Commands/EnvCreateCommand.php
@@ -144,7 +144,7 @@ class EnvCreateCommand extends BuildToolsBase
                 'message' => "Created multidev environment [{$multidev}]({$dashboard_url}) for {$site_name}."
             ];
 
-            $command = $this->interpolate('terminus build:comment:add:commit --message [[message]] --site_url [[site-url]]', $metadata);
+            $command = $this->interpolate('terminus build:comment:add:commit --sha [[sha]] --message [[label]] --site_url "[[site-url]]"', $metadata);
 
             // Run notification command. Ignore errors.
             passthru($command);


### PR DESCRIPTION
We must pass sha to the commit comment command rather than take current local working copy sha.