### PR TITLE
BitBucket Username and Password need to be URL encoded in token.

### DIFF
--- a/src/ServiceProviders/RepositoryProviders/Bitbucket/BitbucketProvider.php
+++ b/src/ServiceProviders/RepositoryProviders/Bitbucket/BitbucketProvider.php
@@ -125,9 +125,9 @@ class BitbucketProvider implements GitProvider, LoggerAwareInterface, Credential
         $this->setBitBucketUser($credentials_provider->fetch(self::BITBUCKET_USER));
         $this->setBitBucketPassword($credentials_provider->fetch(self::BITBUCKET_PASS));
         $this->setToken(
-            $this->getBitBucketUser()
+            urlencode($this->getBitBucketUser())
             .':'.
-            $this->getBitBucketPassword()
+            urlencode($this->getBitBucketPassword())
         );
     }
 


### PR DESCRIPTION
pushRepository() will fail for BitBucket if there is an '@' in either username or password. URL Encoded both sides of the token to escape any unwanted characters in the request.