### PR TITLE
Add CircleCI project page mapping for BitBucket repositories

### DIFF
--- a/src/ServiceProviders/CIProviders/CircleCI/CircleCIProvider.php
+++ b/src/ServiceProviders/CIProviders/CircleCI/CircleCIProvider.php
@@ -168,6 +168,7 @@ class CircleCIProvider implements CIProvider, LoggerAwareInterface, PrivateKeyRe
     {
         $serviceMap = [
             'github' => 'gh',
+            'bitbucket' => 'bb',
         ];
 
         if (isset($serviceMap[$serviceName])) {


### PR DESCRIPTION
This will fix the invalid link/image to CircleCI that is in the generated readme when using a bitbucket repo