### PR TITLE
Use correct URL for GitHub API in `build:env:delete:pr`

### DIFF
--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -794,6 +794,11 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         return preg_replace('#[^:/]*[:/]([^/:]*/[^.]*)\.git#', '\1', str_replace('https://', '', $url));
     }
 
+    protected function orgUserFromRemoteUrl($url)
+    {
+        return preg_match('/^(\w+)@(\w+).(\w+):(.+)\/(.+)(.git)$/', $url, $matches) ? $matches[4] : '';
+    }
+
     protected function preserveEnvsWithOpenPRs($remoteUrl, $oldestEnvironments, $multidev_delete_pattern)
     {
         $project = $this->projectFromRemoteUrl($remoteUrl);

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -806,8 +806,8 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
 
     protected function apiUriFromRemoteUrl($url)
     {
-        $org_user = orgUserFromRemoteUrl($url);
-        $repository = repositoryFromRemoteUrl($url);
+        $org_user = $this->orgUserFromRemoteUrl($url);
+        $repository = $this->repositoryFromRemoteUrl($url);
 
         return "$org_user/$repository";
     }

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -815,9 +815,10 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
     protected function preserveEnvsWithOpenPRs($remoteUrl, $oldestEnvironments, $multidev_delete_pattern)
     {
         $project = $this->projectFromRemoteUrl($remoteUrl);
+        $api_uri = $this->apiUriFromRemoteUrl($remoteUrl);
         // Get back a pr-number => branch-name list
 
-        $closedBranchList = $this->git_provider->branchesForPullRequests($project, 'closed');
+        $closedBranchList = $this->git_provider->branchesForPullRequests($api_uri, 'closed');
 
         // Find any that match "pr-NNN", for some NNN in pr-number.
         $result = $this->findBranches($oldestEnvironments, array_keys($closedBranchList), $multidev_delete_pattern);
@@ -830,7 +831,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
             return $result;
         }
 
-        $openBranchList = $this->git_provider->branchesForPullRequests($project, 'open');
+        $openBranchList = $this->git_provider->branchesForPullRequests($api_uri, 'open');
 
         // Remove any that match "pr-NNN" and have an open pull request
         $result = $this->filterBranches($result, array_keys($openBranchList), $multidev_delete_pattern);

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -814,7 +814,6 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
 
     protected function preserveEnvsWithOpenPRs($remoteUrl, $oldestEnvironments, $multidev_delete_pattern)
     {
-        $project = $this->projectFromRemoteUrl($remoteUrl);
         $api_uri = $this->apiUriFromRemoteUrl($remoteUrl);
         // Get back a pr-number => branch-name list
 

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -804,6 +804,14 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         return preg_match('/^(\w+)@(\w+).(\w+):(.+)\/(.+)(.git)$/', $url, $matches) ? $matches[5] : '';
     }
 
+    protected function apiUriFromRemoteUrl($url)
+    {
+        $org_user = orgUserFromRemoteUrl($url);
+        $repository = repositoryFromRemoteUrl($url);
+
+        return "$org_user/$repository";
+    }
+
     protected function preserveEnvsWithOpenPRs($remoteUrl, $oldestEnvironments, $multidev_delete_pattern)
     {
         $project = $this->projectFromRemoteUrl($remoteUrl);

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -799,6 +799,11 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         return preg_match('/^(\w+)@(\w+).(\w+):(.+)\/(.+)(.git)$/', $url, $matches) ? $matches[4] : '';
     }
 
+    protected function repositoryFromRemoteUrl($url)
+    {
+        return preg_match('/^(\w+)@(\w+).(\w+):(.+)\/(.+)(.git)$/', $url, $matches) ? $matches[5] : '';
+    }
+
     protected function preserveEnvsWithOpenPRs($remoteUrl, $oldestEnvironments, $multidev_delete_pattern)
     {
         $project = $this->projectFromRemoteUrl($remoteUrl);

--- a/src/ServiceProviders/RepositoryProviders/GitHub/GitHubProvider.php
+++ b/src/ServiceProviders/RepositoryProviders/GitHub/GitHubProvider.php
@@ -217,7 +217,7 @@ class GitHubProvider implements GitProvider, LoggerAwareInterface, CredentialCli
 
     protected function gitHubAPI($uri, $data = [], $method = 'GET')
     {
-        $url = "$GITHUB_API_URL/$uri";
+        $url = self::GITHUB_API_URL . '/' . $uri;
 
         $headers = [
             'Content-Type' => 'application/json',

--- a/src/ServiceProviders/RepositoryProviders/GitHub/GitHubProvider.php
+++ b/src/ServiceProviders/RepositoryProviders/GitHub/GitHubProvider.php
@@ -22,6 +22,7 @@ class GitHubProvider implements GitProvider, LoggerAwareInterface, CredentialCli
 
     const SERVICE_NAME = 'github';
     const GITHUB_URL = 'https://github.com';
+    const GITHUB_API_URL = 'https://api.github.com';
     const GITHUB_TOKEN = 'GITHUB_TOKEN';
 
     protected $repositoryEnvironment;
@@ -210,13 +211,13 @@ class GitHubProvider implements GitProvider, LoggerAwareInterface, CredentialCli
             },
             $data
         ), 1, 0);
- 
+
         return $branchList;
      }
 
     protected function gitHubAPI($uri, $data = [], $method = 'GET')
     {
-        $url = "https://api.github.com/$uri";
+        $url = "$GITHUB_API_URL/$uri";
 
         $headers = [
             'Content-Type' => 'application/json',


### PR DESCRIPTION
Fixes the URL that's generated for GitHub's API in `terminus build:env:delete:pr`.

As described in https://github.com/pantheon-systems/terminus-build-tools-plugin/issues/143, `preserveEnvsWithOpenPRs` was constructing the GitHub API endpoint using the SSH git remote. As a result, requests were being made against an invalid URL like this:

`https://api.github.com/repos/git@github.com:{USER}/{REPOSITORY}.git/pulls?state=closed`

GitHub returns a 404 and all `build_and_deploy` jobs on CircleCI fail, blocking any further progress. CircleCI output below:

```
+ terminus build:env:delete:pr -n {SITE} --yes
 [notice] Rsync pr-10.6297eaa1.....@appserver.pr-10.6297eaa1......drush.in:code/build-metadata.json => /tmp/build-metadata.json
 [notice] Call GitHub API: GET repos/git@github.com:{USER}/{REPO}.git/pulls?state=closed
 [error]  Client error: `GET https://api.github.com/repos/git@github.com:{USER}/{REPO}.git/pulls?state=closed` resulted in a `404 Not Found` response:
{"message":"Not Found","documentation_url":"https://developer.github.com/v3/pulls/#list-pull-requests"}
 
Exited with code 148
```

This PR adds an `apiUriFromRemoteUrl` function to the `BuildToolsBase` class that takes the SSH remote `$url` and returns the correct `{ORG_OR_USER}/{REPOSITORY}` string for constructing the GitHub API request. CircleCI output below:

```
+ terminus build:env:delete:pr -n {SITE} --yes
 [notice] Rsync pr-10.6297eaa1.....@appserver.pr-10.6297eaa1......drush.in:code/build-metadata.json => /tmp/build-metadata.json
[notice] Call GitHub API: GET repos/{USER}/{REPO}/pulls?state=closed
[notice] Call GitHub API: GET repos/{USER}/{REPO}/pulls?state=open

[notice] Deleted the multidev environment pr-10.
```

Closes https://github.com/pantheon-systems/terminus-build-tools-plugin/issues/143.