### PR TITLE
Set ssh key gen to use PEM format to address Issue #158 . with CircleCI

### DIFF
--- a/src/Task/Ssh/CreateKeys.php
+++ b/src/Task/Ssh/CreateKeys.php
@@ -77,7 +77,7 @@ class CreateKeys extends BaseTask
         $publicKey = "$privateKey.pub";
 
         // TODO: make a util class method to call passthru and throw on error
-        passthru("ssh-keygen -t rsa -b 4096 -f $privateKey -N '' -C '$ssh_key_email'");
+        passthru("ssh-keygen -m PEM -t rsa -b 4096 -f $privateKey -N '' -C '$ssh_key_email'");
 
         return [$publicKey, $privateKey];
     }


### PR DESCRIPTION
Add -m PEM to ssh-keygen to output key in PEM format so CircleCI API will accept ssh-key

Fixes[ Issue #158 ](https://github.com/pantheon-systems/terminus-build-tools-plugin/issues/158)