### PR TITLE
fix: correct regular expression to parse project

### DIFF
--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -791,7 +791,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
 
     protected function projectFromRemoteUrl($url)
     {
-        return preg_replace('#[^:/]*[:/]([^/:]*/[^.]*)\.git#', '\1', str_replace('https://', '', $url));
+        return preg_replace('#[^:/]*[:/]([^/:]*/.*)\.git#', '\1', str_replace('https://', '', $url));
     }
 
     protected function preserveEnvsWithOpenPRs($remoteUrl, $oldestEnvironments, $multidev_delete_pattern)


### PR DESCRIPTION
Allow the `.` character in the project name.

Fixes #163.