### PR TITLE
Split out GitHub API as a separate object called by the GitHub service provider

### DIFF
--- a/src/API/Bitbucket/BitbucketAPI.php
+++ b/src/API/Bitbucket/BitbucketAPI.php
@@ -17,6 +17,7 @@ class BitbucketAPI extends WebAPI
     const SERVICE_NAME = 'bitbucket';
     const BITBUCKET_USER = 'BITBUCKET_USER';
     const BITBUCKET_PASS = 'BITBUCKET_PASS';
+    const BITBUCKET_AUTH = 'BITBUCKET_AUTH';
 
     public function serviceHumanReadableName()
     {

--- a/src/API/Bitbucket/BitbucketAPI.php
+++ b/src/API/Bitbucket/BitbucketAPI.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Pantheon\TerminusBuildTools\API\Bitbucket;
+
+use Pantheon\TerminusBuildTools\API\WebAPI;
+use Pantheon\TerminusBuildTools\API\WebAPIInterface;
+use Pantheon\TerminusBuildTools\ServiceProviders\ProviderEnvironment;
+use Pantheon\TerminusBuildTools\ServiceProviders\ServiceTokenStorage;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+
+/**
+ * BitbucketAPI manages calls to the Bitbucket API.
+ */
+class BitbucketAPI extends WebAPI
+{
+    const SERVICE_NAME = 'bitbucket';
+    const BITBUCKET_USER = 'BITBUCKET_USER';
+    const BITBUCKET_PASS = 'BITBUCKET_PASS';
+
+    public function serviceHumanReadableName()
+    {
+        return 'Bitbucket';
+    }
+
+    public function serviceName()
+    {
+        return self::SERVICE_NAME;
+    }
+
+    protected function apiClient()
+    {
+        $headers = [
+            'User-Agent' => ProviderEnvironment::USER_AGENT,
+        ];
+
+        return new \GuzzleHttp\Client(
+            [
+                'base_uri' => 'https://api.bitbucket.org/2.0/',
+                'auth' => [ $this->serviceTokenStorage->token(self::BITBUCKET_USER), $this->serviceTokenStorage->token(self::BITBUCKET_PASS) ],
+                'headers' => $headers,
+            ]
+        );
+    }
+
+    protected function isPagedResponse($headers)
+    {
+        return true;
+    }
+
+    protected function getPagerInfo($links)
+    {
+        return [];
+    }
+
+    protected function isLastPage($page_link, $pager_info)
+    {
+        return true;
+    }
+
+    protected function getNextPageUri($pager_info)
+    {
+        return null;
+    }
+}

--- a/src/API/Bitbucket/BitbucketAPITrait.php
+++ b/src/API/Bitbucket/BitbucketAPITrait.php
@@ -52,7 +52,7 @@ trait BitbucketAPITrait
     public function setToken($token)
     {
         $repositoryEnvironment = $this->getEnvironment();
-        $repositoryEnvironment->setToken(self::BITBUCKET_AUTH, $token);
+        $repositoryEnvironment->setToken(BitbucketAPI::BITBUCKET_AUTH, $token);
     }
 
     public function getBitBucketUser()

--- a/src/API/Bitbucket/BitbucketAPITrait.php
+++ b/src/API/Bitbucket/BitbucketAPITrait.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Pantheon\TerminusBuildTools\API\Bitbucket;
+
+use Pantheon\TerminusBuildTools\API\WebAPI;
+use Pantheon\TerminusBuildTools\API\WebAPIInterface;
+use Pantheon\TerminusBuildTools\Credentials\CredentialProviderInterface;
+use Pantheon\TerminusBuildTools\Credentials\CredentialRequest;
+use Pantheon\TerminusBuildTools\ServiceProviders\ProviderEnvironment;
+use Pantheon\TerminusBuildTools\ServiceProviders\ServiceTokenStorage;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+
+/**
+ * BitbucketAPITrait provides access to the BitbucketAPI, and manages
+ * the credentials via a ServiceTokenStorage object
+ */
+trait BitbucketAPITrait
+{
+    protected $bitBucketUser;
+    protected $bitBucketPassword;
+
+    /** @var WebAPIInterface */
+    protected $api;
+
+    /**
+     * @return ServiceTokenStorage
+     */
+    abstract public function getEnvironment();
+
+    public function api()
+    {
+        if (!$this->api) {
+            $this->api = new BitbucketAPI($this->getEnvironment());
+            $this->api->setLogger($this->logger);
+        }
+        return $this->api;
+    }
+
+    public function hasToken($key = false)
+    {
+        $repositoryEnvironment = $this->getEnvironment();
+        return $repositoryEnvironment->hasToken($key);
+    }
+
+    public function token($key = false)
+    {
+        $repositoryEnvironment = $this->getEnvironment();
+        return $repositoryEnvironment->token($key);
+    }
+
+    public function setToken($token)
+    {
+        $repositoryEnvironment = $this->getEnvironment();
+        $repositoryEnvironment->setToken(self::BITBUCKET_AUTH, $token);
+    }
+
+    public function getBitBucketUser()
+    {
+        return $this->bitBucketUser;
+    }
+
+    public function getBitBucketPassword()
+    {
+        return $this->bitBucketPassword;
+    }
+
+    public function setBitBucketUser($u)
+    {
+        $this->bitBucketUser = $u;
+        $repositoryEnvironment = $this->getEnvironment();
+        $repositoryEnvironment->setToken(BitbucketAPI::BITBUCKET_USER, $u);
+    }
+
+    public function setBitBucketPassword($pw)
+    {
+        $this->bitBucketPassword = $pw;
+        $repositoryEnvironment = $this->getEnvironment();
+        $repositoryEnvironment->setToken(BitbucketAPI::BITBUCKET_PASS, $pw);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function credentialRequests()
+    {
+        // Tell the credential manager that we require two credentials
+        $bitbucketUserRequest = new CredentialRequest(
+            BitbucketAPI::BITBUCKET_USER,
+            "",
+            "Enter your Bitbucket username",
+            '#^.+$#',
+            ""
+        );
+
+        $bitbucketPassRequest = new CredentialRequest(
+            BitbucketAPI::BITBUCKET_PASS,
+            "",
+            "Enter your Bitbucket account password or an app password",
+            '#^.+$#',
+            ""
+        );
+
+        return [ $bitbucketUserRequest, $bitbucketPassRequest ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setCredentials(CredentialProviderInterface $credentials_provider)
+    {
+        // Since the `credentialRequests()` method declared that we need a
+        // BITBUCKET_USER and BITBUCKET_PASS credentials, it will be available
+        // for us to copy from the credentials provider when this method is called.
+        $this->setBitBucketUser($credentials_provider->fetch(BitbucketAPI::BITBUCKET_USER));
+        $this->setBitBucketPassword($credentials_provider->fetch(BitbucketAPI::BITBUCKET_PASS));
+        $this->setToken(
+            urlencode($this->getBitBucketUser())
+            .':'.
+            urlencode($this->getBitBucketPassword())
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function authenticatedUser()
+    {
+        return $this->getBitBucketUser();
+    }
+}

--- a/src/API/GitHub/GitHubAPI.php
+++ b/src/API/GitHub/GitHubAPI.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Pantheon\TerminusBuildTools\API\GitHub;
+
+use Pantheon\TerminusBuildTools\API\WebAPI;
+use Pantheon\TerminusBuildTools\API\WebAPIInterface;
+use Pantheon\TerminusBuildTools\ServiceProviders\ProviderEnvironment;
+use Pantheon\TerminusBuildTools\ServiceProviders\ServiceTokenStorage;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+
+/**
+ * GitHubAPI manages calls to the GitHub API.
+ */
+class GitHubAPI extends WebAPI
+{
+    const SERVICE_NAME = 'github';
+    const GITHUB_TOKEN = 'GITHUB_TOKEN';
+
+    public function serviceHumanReadableName()
+    {
+        return 'GitHub';
+    }
+
+    public function serviceName()
+    {
+        return self::SERVICE_NAME;
+    }
+
+    protected function apiClient()
+    {
+        $headers = [
+            'Content-Type' => 'application/json',
+            'User-Agent' => ProviderEnvironment::USER_AGENT,
+        ];
+
+        if ($this->serviceTokenStorage->hasToken(self::GITHUB_TOKEN)) {
+            $headers['Authorization'] = "token " . $this->serviceTokenStorage->token(self::GITHUB_TOKEN);;
+        }
+
+        return new \GuzzleHttp\Client(
+            [
+                'base_uri' => 'https://api.github.com',
+                'headers' => $headers,
+            ]
+        );
+    }
+
+    protected function isPagedResponse($headers)
+    {
+        if (empty($headers['Link'])) {
+            return FALSE;
+        }
+        $links = $headers['Link'];
+        // Find a link header that contains a "rel" type set to "next" or "last".
+        $pager_headers = array_filter($links, function ($link) {
+            return strpos($link, 'rel="next"') !== FALSE || strpos($link, 'rel="last"') !== FALSE;
+        });
+        return !empty($pager_headers);
+    }
+
+    protected function getPagerInfo($links)
+    {
+        $links = $headers['Link'];
+        // Find a link header that contains a "rel" type set to "next" or "last".
+        $pager_headers = array_filter($links, function ($link) {
+            return strpos($link, 'rel="next"') !== FALSE || strpos($link, 'rel="last"') !== FALSE;
+        });
+        // There is only one possible link header.
+        $pager_header = reset($pager_headers);
+        // $pager_header looks like '<https://…>; rel="next", <https://…>; rel="last"'
+        $pager_parts = array_map('trim', explode(',', $pager_header));
+        $parse_link_pager_part = function ($link_pager_part) {
+            // $link_pager_part is '<href>; key1="value1"; key2="value2"'
+            $sub_parts = array_map('trim', explode(';', $link_pager_part));
+
+            $href = array_shift($sub_parts);
+            $href = preg_replace('@^https:\/\/api.github.com\/@', '', trim($href, '<>'));
+            $parsed = ['href' => $href];
+            return array_reduce($sub_parts, function ($carry, $sub_part) {
+                list($key, $value) = explode('=', $sub_part);
+                if (empty($key) || empty($value)) {
+                    return $carry;
+                }
+                return array_merge($carry, [$key => trim($value, '"')]);
+            }, $parsed);
+        };
+        return array_map($parse_link_pager_part, $pager_parts);
+    }
+
+    protected function isLastPage($page_link, $pager_info)
+    {
+        $res = array_filter($pager_info, function ($item) {
+            return isset($item['rel']) && $item['rel'] === 'last';
+        });
+        $last_item = reset($res);
+
+        return isset($last_item) ? $last_item['href'] === $page_link : FALSE;
+    }
+
+    protected function getNextPageUri($pager_info)
+    {
+        $res = array_filter($pager_info, function ($item) {
+            return isset($item['rel']) && $item['rel'] === 'next';
+        });
+        $next_item = reset($res);
+        return isset($next_item['href']) ? $next_item['href'] : NULL;
+    }
+}

--- a/src/API/GitHub/GitHubAPITrait.php
+++ b/src/API/GitHub/GitHubAPITrait.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Pantheon\TerminusBuildTools\API\GitHub;
+
+use Pantheon\TerminusBuildTools\API\WebAPI;
+use Pantheon\TerminusBuildTools\API\WebAPIInterface;
+use Pantheon\TerminusBuildTools\Credentials\CredentialProviderInterface;
+use Pantheon\TerminusBuildTools\Credentials\CredentialRequest;
+use Pantheon\TerminusBuildTools\ServiceProviders\ProviderEnvironment;
+use Pantheon\TerminusBuildTools\ServiceProviders\ServiceTokenStorage;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+
+/**
+ * BitbucketAPITrait provides access to the BitbucketAPI, and manages
+ * the credentials via a ServiceTokenStorage object
+ */
+trait GitHubAPITrait
+{
+    /** @var WebAPIInterface */
+    protected $api;
+
+    public function api()
+    {
+        if (!$this->api) {
+            $this->api = new GitHubAPI($this->getEnvironment());
+            $this->api->setLogger($this->logger);
+        }
+        return $this->api;
+    }
+
+    public function tokenKey()
+    {
+        return GitHubAPI::GITHUB_TOKEN;
+    }
+
+    public function hasToken($key = false)
+    {
+        $repositoryEnvironment = $this->getEnvironment();
+        return $repositoryEnvironment->hasToken($key);
+    }
+
+    public function token($key = false)
+    {
+        $repositoryEnvironment = $this->getEnvironment();
+        return $repositoryEnvironment->token($key);
+    }
+
+    public function setToken($token)
+    {
+        $repositoryEnvironment = $this->getEnvironment();
+        $repositoryEnvironment->setToken($this->tokenKey(), $token);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function credentialRequests()
+    {
+        // Tell the credential manager that we require one credential: the
+        // GITHUB_TOKEN that will be used to authenticate with the CircleCI server.
+        $githubTokenRequest = new CredentialRequest(
+            $this->tokenKey(),
+            "Please generate a GitHub personal access token by visiting the page:\n\n    https://github.com/settings/tokens\n\n For more information, see:\n\n    https://help.github.com/articles/creating-an-access-token-for-command-line-use.\n\n Give it the 'repo' (required) and 'delete-repo' (optional) scopes.",
+            "Enter GitHub personal access token: ",
+            '#^[0-9a-fA-F]{40}$#',
+            'GitHub authentication tokens should be 40-character strings containing only the letters a-f and digits (0-9). Please enter your token again.'
+        );
+
+        return [ $githubTokenRequest ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setCredentials(CredentialProviderInterface $credentials_provider)
+    {
+        // Since the `credentialRequests()` method declared that we need a
+        // GITHUB_TOKEN credential, it will be available for us to copy from
+        // the credentials provider when this method is called.
+        $tokenKey = $this->tokenKey();
+        $token = $credentials_provider->fetch($tokenKey);
+        if (!$token) {
+            throw new \Exception('Could not determine authentication token for GitHub serivces. Please set ' . $tokenKey);
+        }
+        $this->setToken($token);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function authenticatedUser()
+    {
+        $userData = $this->api()->request('user');
+        return $userData['login'];
+    }
+}

--- a/src/API/PullRequestInfo.php
+++ b/src/API/PullRequestInfo.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Pantheon\TerminusBuildTools\API;
+
+/**
+ * PullRequestInfo caches info about pull requests
+ */
+interface PullRequestInfo
+{
+    protected $prNumber;
+    protected $isClosed;
+    protected $branchName;
+
+    public function __construct($prNumber, $isClosed, $branchName)
+    {
+        $this->prNumber = $prNumber;
+        $this->isClosed = $isClosed;
+        $this->branchName = $branchName;
+    }
+
+    public function prNumber()
+    {
+        return $this->prNumber;
+    }
+
+    public function isClosed()
+    {
+        return $this->isClosed;
+    }
+
+    public function branchName()
+    {
+        return $this->branchName();
+    }
+}

--- a/src/API/WebAPI.php
+++ b/src/API/WebAPI.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Pantheon\TerminusBuildTools\API;
+
+use Pantheon\TerminusBuildTools\API\WebAPI;
+use Pantheon\TerminusBuildTools\ServiceProviders\ProviderEnvironment;
+use Pantheon\TerminusBuildTools\ServiceProviders\ServiceTokenStorage;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+
+/**
+ * WebAPI is an abstract class for managing web APIs for different services.
+ */
+abstract class WebAPI implements WebAPIInterface, LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    /** @var ServiceTokenStorage */
+    protected $serviceTokenStorage;
+
+    public function __construct(ServiceTokenStorage $serviceTokenStorage)
+    {
+        $this->serviceTokenStorage = $serviceTokenStorage;
+    }
+
+    abstract protected function apiClient();
+
+    abstract protected function isPagedResponse($headers);
+
+    abstract protected function getPagerInfo($links);
+
+    abstract protected function isLastPage($page_link, $pager_info);
+
+    abstract protected function getNextPageUri($pager_info);
+
+    public function request($uri, $data = [], $method = 'GET')
+    {
+        $res = $this->sendRequest($uri, $data, $method);
+
+        $resultData = json_decode($res->getBody(), true);
+        $httpCode = $res->getStatusCode();
+
+        return $this->processResponse($resultData, $httpCode);
+    }
+
+    public function pagedRequest($uri, $callback = null)
+    {
+        $res = $this->sendRequest($uri);
+
+        $resultData = json_decode($res->getBody(), true);
+        $httpCode = $res->getStatusCode();
+
+        // Remember all of the collected data in $accumulatedData
+        $accumulatedData = $resultData;
+
+        // The request may be against a paged collection. If that is the case, traverse the "next" links sequentially
+        // (since it's simpler and PHP doesn't have non-blocking I/O) until the end and accumulate the results.
+        $headers = $res->getHeaders();
+        // Check if the array is numeric. Otherwise we can't consider this a collection.
+        if ($this->isSequentialArray($resultData) && $this->isPagedResponse($headers)) {
+            $pager_info = $this->getPagerInfo($headers);
+            $isDone = false;
+            while (($httpCode == 200) && !$isDone && $this->checkPagedCallback($resultData, $callback)) {
+                $isDone = $this->isLastPage($uri, $pager_info);
+                $uri = $this->getNextPageUri($pager_info);
+
+                $res = $this->sendRequest($uri);
+                $httpCode = $res->getStatusCode();
+                $resultData = json_decode($res->getBody(), true);
+
+                $accumulatedData = array_merge_recursive(
+                    $accumulatedData,
+                    $resultData
+                );
+
+            }
+        }
+
+        return $this->processResponse($accumulatedData, $httpCode);
+    }
+
+    protected function sendRequest($uri, $data = [], $method = 'GET')
+    {
+        $guzzleParams = [];
+        if (!empty($data)) {
+            if  ($method == 'GET') {
+                $method = 'POST';
+            }
+            $guzzleParams['json'] = $data;
+        }
+
+        $this->logger->notice('Call {service} API: {method} {uri}', ['service' => $this->serviceHumanReadableName(), 'method' => $method, 'uri' => $uri]);
+
+        $client = $this->apiClient();
+        return $client->request($method, $uri, $guzzleParams);
+    }
+
+    protected function checkPagedCallback($resultData, $callback)
+    {
+        if (!$callback) {
+            return true;
+        }
+
+        return $callback($resultData);
+    }
+
+    protected function processResponse($resultData, $httpCode)
+    {
+        $errors = [];
+        if (isset($resultData['errors'])) {
+            foreach ($resultData['errors'] as $error) {
+                $errors[] = $error['message'];
+            }
+        }
+        if ($httpCode && ($httpCode >= 300)) {
+            $errors[] = "Http status code: $httpCode";
+        }
+
+        $message = isset($resultData['message']) ? "{$resultData['message']}." : '';
+
+        if (!empty($message) || !empty($errors)) {
+            throw new TerminusException('error: {message} {errors}', ['message' => $message, 'errors' => implode("\n", $errors)]);
+        }
+
+        return $resultData;
+    }
+
+    protected function isSequentialArray($input)
+    {
+        if (!is_array($input)) {
+            return FALSE;
+        }
+        if (empty($input)) {
+            return TRUE;
+        }
+        $keys = array_keys($input);
+        $keys_of_keys = array_keys($keys);
+        for ($i = 0; $i < count($keys); $i++) {
+            if ($keys[$i] !== $keys_of_keys[$i]) {
+                return FALSE;
+            }
+        }
+        return TRUE;
+    }
+}

--- a/src/API/WebAPIInterface.php
+++ b/src/API/WebAPIInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Pantheon\TerminusBuildTools\API;
+
+/**
+ * WebAPI represents an interface to a remote API (GitHub, BitBucket, GitLab, etc.)
+ */
+interface WebAPIInterface
+{
+    public function serviceName();
+    public function request($uri, $data = [], $method = 'GET');
+    public function pagedRequest($uri, $callback = null);
+}

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -196,19 +196,6 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
     }
 
     /**
-     * Fetch the environment variable 'GITHUB_TOKEN', or throw an exception if it is not set.
-     * @return string
-     */
-    protected function getRequiredGithubToken()
-    {
-        $github_token = getenv('GITHUB_TOKEN');
-        if (empty($github_token)) {
-            throw new TerminusException("Please generate a GitHub personal access token token, as described in https://help.github.com/articles/creating-an-access-token-for-command-line-use/. Then run: \n\nexport GITHUB_TOKEN=my_personal_access_token_value");
-        }
-        return $github_token;
-    }
-
-    /**
      * Fetch the environment variable 'CIRCLE_TOKEN', or throw an exception if it is not set.
      * @return string
      */

--- a/src/ServiceProviders/ProviderEnvironment.php
+++ b/src/ServiceProviders/ProviderEnvironment.php
@@ -4,15 +4,73 @@ namespace Pantheon\TerminusBuildTools\ServiceProviders;
 
 /**
  * Store variables relevant to a provider.
+ *
+ * Use like an ArrayObject to cache transient variables.
+ *
+ * Use setToken / token to get / fetch variables that should be
+ * persisted with the CI service.
  */
-class ProviderEnvironment extends \ArrayObject
+class ProviderEnvironment extends \ArrayObject implements ServiceTokenStorage
 {
-
     const USER_AGENT = 'pantheon/terminus-build-tools-plugin';
+
+    protected $token_key = 'TOKEN';
+    protected $tokens = [];
+    protected $serviceName;
 
     public function __construct(array $data = [])
     {
         parent::__construct($data);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function hasToken($key = false)
+    {
+        if (!$key) {
+            $key = $this->token_key;
+        }
+        return in_array($key, $this->tokens);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function token($key = false)
+    {
+        if (!$key) {
+            $key = $this->token_key;
+        }
+        return $this[$key];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setToken($key, $token)
+    {
+        $this->token_key = $key;
+        $this->tokens[] = $key;
+        $this[$key] = $token;
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function serviceName()
+    {
+        return $this->serviceName;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setServiceName($serviceName)
+    {
+        $this->serviceName = $serviceName;
+        return $this;
     }
 
     /**

--- a/src/ServiceProviders/RepositoryProviders/Bitbucket/BitbucketProvider.php
+++ b/src/ServiceProviders/RepositoryProviders/Bitbucket/BitbucketProvider.php
@@ -7,11 +7,11 @@ use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 
 use Pantheon\TerminusBuildTools\Credentials\CredentialClientInterface;
-use Pantheon\TerminusBuildTools\Credentials\CredentialProviderInterface;
 use Pantheon\TerminusBuildTools\ServiceProviders\RepositoryProviders\GitProvider;
-use Pantheon\TerminusBuildTools\Credentials\CredentialRequest;
 use Pantheon\TerminusBuildTools\Utility\ExecWithRedactionTrait;
 use Pantheon\TerminusBuildTools\ServiceProviders\RepositoryProviders\RepositoryEnvironment;
+use Pantheon\TerminusBuildTools\API\Bitbucket\BitbucketAPI;
+use Pantheon\TerminusBuildTools\API\Bitbucket\BitbucketAPITrait;
 
 use GuzzleHttp\Client;
 
@@ -22,17 +22,14 @@ class BitbucketProvider implements GitProvider, LoggerAwareInterface, Credential
 {
     use LoggerAwareTrait;
     use ExecWithRedactionTrait;
+    use BitbucketAPITrait;
 
     const SERVICE_NAME = 'bitbucket';
     const BITBUCKET_URL = 'https://bitbucket.org';
-    const BITBUCKET_USER = 'BITBUCKET_USER';
-    const BITBUCKET_PASS = 'BITBUCKET_PASS';
     const BITBUCKET_AUTH = 'BITBUCKET_AUTH';
 
     private $bitbucketClient;
     protected $repositoryEnvironment;
-    protected $bitBucketUser;
-    protected $bitBucketPassword;
 
     public function __construct()
     {
@@ -52,94 +49,6 @@ class BitbucketProvider implements GitProvider, LoggerAwareInterface, Credential
         return $this->repositoryEnvironment;
     }
 
-    public function hasToken()
-    {
-        $repositoryEnvironment = $this->getEnvironment();
-        return $repositoryEnvironment->hasToken();
-    }
-
-    public function token()
-    {
-        $repositoryEnvironment = $this->getEnvironment();
-        return $repositoryEnvironment->token();
-    }
-
-    public function setToken($token)
-    {
-        $repositoryEnvironment = $this->getEnvironment();
-        $repositoryEnvironment->setToken(self::BITBUCKET_AUTH, $token);
-    }
-
-    public function getBitBucketUser()
-    {
-        return $this->bitBucketUser;
-    }
-
-    public function getBitBucketPassword()
-    {
-        return $this->bitBucketPassword;
-    }
-
-    public function setBitBucketUser($u)
-    {
-        $this->bitBucketUser = $u;
-    }
-
-    public function setBitBucketPassword($pw)
-    {
-        $this->bitBucketPassword = $pw;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function credentialRequests()
-    {
-        // Tell the credential manager that we require two credentials
-        $bitbucketUserRequest = new CredentialRequest(
-            self::BITBUCKET_USER,
-            "",
-            "Enter your Bitbucket username",
-            '#^.+$#',
-            ""
-        );
-
-        $bitbucketPassRequest = new CredentialRequest(
-            self::BITBUCKET_PASS,
-            "",
-            "Enter your Bitbucket account password or an app password",
-            '#^.+$#',
-            ""
-        );
-
-        return [ $bitbucketUserRequest, $bitbucketPassRequest ];
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function setCredentials(CredentialProviderInterface $credentials_provider)
-    {
-        // Since the `credentialRequests()` method declared that we need a
-        // BITBUCKET_USER and BITBUCKET_PASS credentials, it will be available
-        // for us to copy from the credentials provider when this method is called.
-        $this->setBitBucketUser($credentials_provider->fetch(self::BITBUCKET_USER));
-        $this->setBitBucketPassword($credentials_provider->fetch(self::BITBUCKET_PASS));
-        $this->setToken(
-            urlencode($this->getBitBucketUser())
-            .':'.
-            urlencode($this->getBitBucketPassword())
-        );
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function authenticatedUser()
-    {
-        return $this->getBitBucketUser();
-    }
-
     /**
      * @inheritdoc
      */
@@ -157,7 +66,7 @@ class BitbucketProvider implements GitProvider, LoggerAwareInterface, Credential
 
         // Create a Bitbucket repository
         $this->logger->notice('Creating repository {repo}', ['repo' => $target_project]);
-        $result = $this->bitbucketAPI('repositories/'.$target_project, 'PUT');
+        $result = $this->api()->request("repositories/$target_project", [], 'PUT');
 
         // Create a git repository. Add an origin just to have the data there
         // when collecting the build metadata later. We use the 'pantheon'
@@ -202,18 +111,19 @@ class BitbucketProvider implements GitProvider, LoggerAwareInterface, Credential
      */
     public function commentOnCommit($target_project, $commit_hash, $message)
     {
-        // We're using the 1.0 API here because this is not yet supported in 2.0
-        $url = "/1.0/repositories/$target_project/changesets/$commit_hash/comments";
-        $data = [ 'content' => $message ];
-        $this->bitbucketAPIClient()->post($url, [
-           'form_params' => $data
-        ]);
+        $body = [
+            'content' => [
+                'raw' => $message,
+            ],
+            // 'parent' => '???', // not sure if this is needed
+        ];
+        $result = $this->api()->request("repositories/$target_project/commit/$commit_hash/comments", $body);
     }
 
     /**
      * @inheritdoc
      */
-    function branchesForPullRequests($target_project, $state)
+    function branchesForPullRequests($target_project, $state, $callback = null)
     {
         $stateParameters = [
             'open' => ['OPEN'],
@@ -222,9 +132,9 @@ class BitbucketProvider implements GitProvider, LoggerAwareInterface, Credential
         ];
         if (!isset($stateParameters[$state]))
             throw new TerminusException("branchesForPullRequests - state must be one of: open, closed, all");
-        
-        $data = $this->bitbucketAPI("repositories/$target_project/pullrequests?state="
-            .implode('&state=', $stateParameters[$state]));
+
+        $data = $this->api()->pagedRequest("repositories/$target_project/pullrequests?state="
+            .implode('&state=', $stateParameters[$state]), $callback);
 
         $branchList = array_column(array_map(
             function ($item) {
@@ -238,49 +148,10 @@ class BitbucketProvider implements GitProvider, LoggerAwareInterface, Credential
         return $branchList;
     }
 
-    private function bitbucketAPIClient()
+    public function convertPRInfo($data)
     {
-        if (!isset($this->bitbucketClient))
-            $this->bitbucketClient = new Client([
-                'base_uri' => 'https://api.bitbucket.org/2.0/',
-                'auth' => [ $this->getBitBucketUser(), $this->getBitBucketPassword() ],
-                'headers' => [
-                    'User-Agent' => ProviderEnvironment::USER_AGENT,
-                ]
-            ]);
-        return $this->bitbucketClient;
-    }
-
-    protected function bitbucketAPI($uri, $method = 'GET', $data = [])
-    {
-        $guzzleParams = [];
-        if (!empty($data)) {
-            $guzzleParams['json'] = $data;
-        }
-
-        $this->logger->notice('Call Bitbucket API: {method} {uri}', ['method' => $method, 'uri' => $uri]);
-        
-        $res = $this->bitbucketAPIClient()->request($method, $uri, $guzzleParams);
-        $resultData = json_decode($res->getBody(), true);
-        $httpCode = $res->getStatusCode();
-
-        $errors = [];
-        if (isset($resultData['errors'])) {
-            foreach ($resultData['errors'] as $error) {
-                $errors[] = $error['message'];
-            }
-        }
-        if ($httpCode && ($httpCode >= 300)) {
-            $errors[] = "Http status code: $httpCode";
-        }
-
-        $message = isset($resultData['message']) ? "{$resultData['message']}." : '';
-
-        if (!empty($message) || !empty($errors)) {
-            throw new TerminusException('{service} error: {message} {errors}', ['service' => $service, 'message' => $message, 'errors' => implode("\n", $errors)]);
-        }
-
-        return $resultData;
+        $isClosed = ($data['state'] != 'OPEN');
+        return new PullRequestInfo($data['id'], $isClosed, $data['source']['branch']['name']);
     }
 
     protected function execGit($dir, $cmd, $replacements = [], $redacted = [])

--- a/src/ServiceProviders/RepositoryProviders/GitHub/GitHubProvider.php
+++ b/src/ServiceProviders/RepositoryProviders/GitHub/GitHubProvider.php
@@ -7,11 +7,12 @@ use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Pantheon\Terminus\Exceptions\TerminusException;
 use Pantheon\TerminusBuildTools\Credentials\CredentialClientInterface;
-use Pantheon\TerminusBuildTools\Credentials\CredentialProviderInterface;
 use Pantheon\TerminusBuildTools\ServiceProviders\RepositoryProviders\GitProvider;
 use Pantheon\TerminusBuildTools\Credentials\CredentialRequest;
 use Pantheon\TerminusBuildTools\Utility\ExecWithRedactionTrait;
 use Pantheon\TerminusBuildTools\ServiceProviders\RepositoryProviders\RepositoryEnvironment;
+use Pantheon\TerminusBuildTools\API\GitHub\GitHubAPI;
+use Pantheon\TerminusBuildTools\API\GitHub\GitHubAPITrait;
 
 /**
  * Holds state information destined to be registered with the CI service.
@@ -20,12 +21,15 @@ class GitHubProvider implements GitProvider, LoggerAwareInterface, CredentialCli
 {
     use LoggerAwareTrait;
     use ExecWithRedactionTrait;
+    use GitHubAPITrait;
 
     const SERVICE_NAME = 'github';
     const GITHUB_URL = 'https://github.com';
-    const GITHUB_TOKEN = 'GITHUB_TOKEN';
 
     protected $repositoryEnvironment;
+
+    /** @var WebAPIInterface */
+    protected $api;
 
     public function __construct()
     {
@@ -45,72 +49,6 @@ class GitHubProvider implements GitProvider, LoggerAwareInterface, CredentialCli
         return $this->repositoryEnvironment;
     }
 
-  public function tokenKey()
-    {
-        return self::GITHUB_TOKEN;
-    }
-
-    public function hasToken()
-    {
-        $repositoryEnvironment = $this->getEnvironment();
-        return $repositoryEnvironment->hasToken();
-    }
-
-    public function token()
-    {
-        $repositoryEnvironment = $this->getEnvironment();
-        return $repositoryEnvironment->token();
-    }
-
-    public function setToken($token)
-    {
-        $repositoryEnvironment = $this->getEnvironment();
-        $repositoryEnvironment->setToken($this->tokenKey(), $token);
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function credentialRequests()
-    {
-        // Tell the credential manager that we require one credential: the
-        // GITHUB_TOKEN that will be used to authenticate with the CircleCI server.
-        $githubTokenRequest = new CredentialRequest(
-            $this->tokenKey(),
-            "Please generate a GitHub personal access token by visiting the page:\n\n    https://github.com/settings/tokens\n\n For more information, see:\n\n    https://help.github.com/articles/creating-an-access-token-for-command-line-use.\n\n Give it the 'repo' (required) and 'delete-repo' (optional) scopes.",
-            "Enter GitHub personal access token: ",
-            '#^[0-9a-fA-F]{40}$#',
-            'GitHub authentication tokens should be 40-character strings containing only the letters a-f and digits (0-9). Please enter your token again.'
-        );
-
-        return [ $githubTokenRequest ];
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function setCredentials(CredentialProviderInterface $credentials_provider)
-    {
-        // Since the `credentialRequests()` method declared that we need a
-        // GITHUB_TOKEN credential, it will be available for us to copy from
-        // the credentials provider when this method is called.
-        $tokenKey = $this->tokenKey();
-        $token = $credentials_provider->fetch($tokenKey);
-        if (!$token) {
-            throw new \Exception('Could not determine authentication token for GitHub serivces. Please set ' . $tokenKey);
-        }
-        $this->setToken($token);
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function authenticatedUser()
-    {
-        $userData = $this->gitHubAPI('user');
-        return $userData['login'];
-    }
-
     /**
      * @inheritdoc
      */
@@ -123,7 +61,7 @@ class GitHubProvider implements GitProvider, LoggerAwareInterface, CredentialCli
         $target_org = $github_org;
         if (empty($github_org)) {
             $createRepoUrl = 'user/repos';
-            $userData = $this->gitHubAPI('user');
+            $userData = $this->api()->request('user');
             $target_org = $this->authenticatedUser();
         }
         $target_project = "$target_org/$target";
@@ -131,7 +69,7 @@ class GitHubProvider implements GitProvider, LoggerAwareInterface, CredentialCli
         // Create a GitHub repository
         $this->logger->notice('Creating repository {repo}', ['repo' => $target_project]);
         $postData = ['name' => $target];
-        $result = $this->gitHubAPI($createRepoUrl, $postData);
+        $result = $this->api()->request($createRepoUrl, $postData);
 
         // Create a git repository. Add an origin just to have the data there
         // when collecting the build metadata later. We use the 'pantheon'
@@ -173,7 +111,7 @@ class GitHubProvider implements GitProvider, LoggerAwareInterface, CredentialCli
     public function deleteRepository($project)
     {
         $deleteRepoUrl = "repos/$project";
-        $this->gitHubAPI($deleteRepoUrl, [], 'DELETE');
+        $this->api()->request($deleteRepoUrl, [], 'DELETE');
     }
 
     /**
@@ -191,18 +129,18 @@ class GitHubProvider implements GitProvider, LoggerAwareInterface, CredentialCli
     {
         $url = "repos/$target_project/commits/$commit_hash/comments";
         $data = [ 'body' => $message ];
-        $this->gitHubAPI($url, $data);
+        $this->api()->request($url, $data);
     }
 
     /**
      * @inheritdoc
      */
-    function branchesForPullRequests($target_project, $state, $callback = null)
+    public function branchesForPullRequests($target_project, $state, $callback = null)
     {
         if (!in_array($state, ['open', 'closed', 'all']))
             throw new TerminusException("branchesForPullRequests - state must be one of: open, closed, all");
 
-        $data = $this->gitHubPagedAPI("repos/$target_project/pulls?state=$state", $callback);
+        $data = $this->api()->pagedRequest("repos/$target_project/pulls?state=$state", $callback);
         $branchList = array_column(array_map(
             function ($item) {
                 $pr_number = $item['number'];
@@ -215,188 +153,10 @@ class GitHubProvider implements GitProvider, LoggerAwareInterface, CredentialCli
         return $branchList;
     }
 
-    protected function gitHubAPI($uri, $data = [], $method = 'GET')
+    public function convertPRInfo($data)
     {
-        $res = $this->getHubRequest($uri, $data, $method);
-
-        $resultData = json_decode($res->getBody(), true);
-        $httpCode = $res->getStatusCode();
-
-        return $this->processGitHubResponse($resultData, $httpCode);
-    }
-
-    protected function gitHubPagedAPI($uri, $callback = null)
-    {
-        $res = $this->getHubRequest($uri);
-
-        $resultData = json_decode($res->getBody(), true);
-        $httpCode = $res->getStatusCode();
-
-        // Remember all of the collected data in $accumulatedData
-        $accumulatedData = $resultData;
-
-        // The request may be against a paged collection. If that is the case, traverse the "next" links sequentially
-        // (since it's simpler and PHP doesn't have non-blocking I/O) until the end and accumulate the results.
-        $headers = $res->getHeaders();
-        // Check if the array is numeric. Otherwise we can't consider this a collection. Ideally GitHub would tell us
-        // that the response is a collection but we'll need to guess from the response format.
-        if ($this->isSequentialArray($resultData) && $this->isPagedResponse($headers)) {
-            $pager_info = $this->getPagerInfo($headers['Link']);
-            $isDone = false;
-            while (($httpCode == 200) && !$isDone && $this->checkPagedCallback($resultData, $callback)) {
-                $isDone = $this->isLastPage($uri, $pager_info);
-                $uri = $this->getNextPageUri($pager_info);
-
-                $res = $this->getHubRequest($uri);
-                $httpCode = $res->getStatusCode();
-                $resultData = json_decode($res->getBody(), true);
-
-                $accumulatedData = array_merge_recursive(
-                    $accumulatedData,
-                    $resultData
-                );
-
-            }
-        }
-
-        return $this->processGitHubResponse($accumulatedData, $httpCode);
-    }
-
-    protected function checkPagedCallback($resultData, $callback)
-    {
-        if (!$callback) {
-            return true;
-        }
-
-        return $callback($resultData);
-    }
-
-    protected function getHubRequest($uri, $data = [], $method = 'GET')
-    {
-        $url = "https://api.github.com/$uri";
-
-        $headers = [
-            'Content-Type' => 'application/json',
-            'User-Agent' => ProviderEnvironment::USER_AGENT,
-        ];
-
-        if ($this->hasToken()) {
-            $headers['Authorization'] = "token " . $this->token();;
-        }
-
-        $guzzleParams = [
-            'headers' => $headers,
-        ];
-        if (!empty($data) && ($method == 'GET')) {
-            $method = 'POST';
-            $guzzleParams['json'] = $data;
-        }
-
-        $this->logger->notice('Call GitHub API: {method} {uri}', ['method' => $method, 'uri' => $uri]);
-
-        $client = new \GuzzleHttp\Client();
-        $res = $client->request($method, $url, $guzzleParams);
-
-        return $res;
-    }
-
-    protected function processGitHubResponse($resultData, $httpCode)
-    {
-        $errors = [];
-        if (isset($resultData['errors'])) {
-            foreach ($resultData['errors'] as $error) {
-                $errors[] = $error['message'];
-            }
-        }
-        if ($httpCode && ($httpCode >= 300)) {
-            $errors[] = "Http status code: $httpCode";
-        }
-
-        $message = isset($resultData['message']) ? "{$resultData['message']}." : '';
-
-        if (!empty($message) || !empty($errors)) {
-            throw new TerminusException('error: {message} {errors}', ['message' => $message, 'errors' => implode("\n", $errors)]);
-        }
-
-        return $resultData;
-    }
-
-    protected function isSequentialArray($input)
-    {
-        if (!is_array($input)) {
-            return FALSE;
-        }
-        if (empty($input)) {
-            return TRUE;
-        }
-        $keys = array_keys($input);
-        $keys_of_keys = array_keys($keys);
-        for ($i = 0; $i < count($keys); $i++) {
-            if ($keys[$i] !== $keys_of_keys[$i]) {
-                return FALSE;
-            }
-        }
-        return TRUE;
-    }
-
-    protected function isPagedResponse($headers)
-    {
-        if (empty($headers['Link'])) {
-            return FALSE;
-        }
-        $links = $headers['Link'];
-        // Find a link header that contains a "rel" type set to "next" or "last".
-        $pager_headers = array_filter($links, function ($link) {
-            return strpos($link, 'rel="next"') !== FALSE || strpos($link, 'rel="last"') !== FALSE;
-        });
-        return !empty($pager_headers);
-    }
-
-    protected function getPagerInfo($links)
-    {
-        // Find a link header that contains a "rel" type set to "next" or "last".
-        $pager_headers = array_filter($links, function ($link) {
-            return strpos($link, 'rel="next"') !== FALSE || strpos($link, 'rel="last"') !== FALSE;
-        });
-        // There is only one possible link header.
-        $pager_header = reset($pager_headers);
-        // $pager_header looks like '<https://…>; rel="next", <https://…>; rel="last"'
-        $pager_parts = array_map('trim', explode(',', $pager_header));
-        $parse_link_pager_part = function ($link_pager_part) {
-            // $link_pager_part is '<href>; key1="value1"; key2="value2"'
-            $sub_parts = array_map('trim', explode(';', $link_pager_part));
-
-            $href = array_shift($sub_parts);
-            $href = preg_replace('@^https:\/\/api.github.com\/@', '', trim($href, '<>'));
-            $parsed = ['href' => $href];
-            return array_reduce($sub_parts, function ($carry, $sub_part) {
-                list($key, $value) = explode('=', $sub_part);
-                if (empty($key) || empty($value)) {
-                    return $carry;
-                }
-                return array_merge($carry, [$key => trim($value, '"')]);
-            }, $parsed);
-        };
-        return array_map($parse_link_pager_part, $pager_parts);
-    }
-
-    protected function isLastPage($page_link, $pager_info)
-    {
-        $res = array_filter($pager_info, function ($item) {
-            return isset($item['rel']) && $item['rel'] === 'last';
-        });
-        $last_item = reset($res);
-
-        return isset($last_item) ? $last_item['href'] === $page_link : FALSE;
-    }
-
-    protected function getNextPageUri($pager_info)
-    {
-        $res = array_filter($pager_info, function ($item) {
-            return isset($item['rel']) && $item['rel'] === 'next';
-        });
-        $next_item = reset($res);
-        return isset($next_item['href']) ? $next_item['href'] : NULL;
+        $isClosed = ($data['state'] == 'closed');
+        return new PullRequestInfo($data['number'], $isClosed, $data['head']['ref']);
     }
 
     protected function execGit($dir, $cmd, $replacements = [], $redacted = [])

--- a/src/ServiceProviders/RepositoryProviders/GitLab/GitLabProvider.php
+++ b/src/ServiceProviders/RepositoryProviders/GitLab/GitLabProvider.php
@@ -72,16 +72,16 @@ class GitLabProvider implements GitProvider, LoggerAwareInterface, CredentialCli
         return self::GITLAB_TOKEN;
     }
 
-    public function hasToken()
+    public function hasToken($key = false)
     {
         $repositoryEnvironment = $this->getEnvironment();
-        return $repositoryEnvironment->hasToken();
+        return $repositoryEnvironment->hasToken($key);
     }
 
-    public function token()
+    public function token($key = false)
     {
         $repositoryEnvironment = $this->getEnvironment();
-        return $repositoryEnvironment->token();
+        return $repositoryEnvironment->token($key);
     }
 
     public function setToken($token)

--- a/src/ServiceProviders/RepositoryProviders/RepositoryEnvironment.php
+++ b/src/ServiceProviders/RepositoryProviders/RepositoryEnvironment.php
@@ -6,37 +6,7 @@ use Pantheon\TerminusBuildTools\ServiceProviders\ProviderEnvironment;
 
 class RepositoryEnvironment extends ProviderEnvironment
 {
-    protected $token_key = 'TOKEN';
-    protected $serviceName;
     protected $projectId;
-
-    public function hasToken()
-    {
-        return isset($this[$this->token_key]);
-    }
-
-    public function token()
-    {
-        return $this[$this->token_key];
-    }
-
-    public function setToken($key, $token)
-    {
-        $this->token_key = $key;
-        $this[$key] = $token;
-        return $this;
-    }
-
-    public function serviceName()
-    {
-        return $this->serviceName;
-    }
-
-    public function setServiceName($serviceName)
-    {
-        $this->serviceName = $serviceName;
-        return $this;
-    }
 
     /**
      * Project identifier (org/projectname)
@@ -56,8 +26,11 @@ class RepositoryEnvironment extends ProviderEnvironment
         return $this;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function ciState()
     {
-        return $this->getElements([$this->token_key]);
+        return $this->getElements($this->tokens);
     }
 }

--- a/src/ServiceProviders/ServiceTokenStorage.php
+++ b/src/ServiceProviders/ServiceTokenStorage.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Pantheon\TerminusBuildTools\ServiceProviders;
+
+/**
+ * An object that keeps track of the token for a service.
+ *
+ * For services with only one token, clients do not need to keep
+ * track of the token name. For those that require multiple tokens
+ * (e.g. bitbucket needs username and password / app password), the
+ * key must be provided.
+ */
+interface ServiceTokenStorage
+{
+    /**
+     * hasToken returns whether the storage object has a / the security token.
+     *
+     * @param string $key The token name. Optional; defaults to last key set.
+     * @return bool
+     */
+    public function hasToken($key = false);
+
+    /**
+     * token returns a / the security token
+     *
+     * @param string $key The token name. Optional; defaults to last key set.
+     * @return string
+     */
+    public function token($key = false);
+
+    /**
+     * setToken stores the given token for later use.
+     */
+    public function setToken($key, $token);
+}

--- a/src/Utility/MultiDevRetention.php
+++ b/src/Utility/MultiDevRetention.php
@@ -127,19 +127,20 @@ class MultiDevRetention
      */
     public function __invoke($resultData)
     {
-        foreach ($resultData as $item) {
-            $this->process($item);
+        foreach ($resultData as $data) {
+            $prInfo = $this->$provider->convertPRInfo($data);
+            $this->process($prInfo);
         }
 
         return !empty($this->examining);
     }
 
-    protected function process($item)
+    protected function process($prInfo)
     {
-        $number = $item['number'];
-        $name = $this->pattern . $number;
+        $prNumber = $prInfo->prNumber();
+        $name = $this->pattern . $prNumber;
 
-        if ($item['state'] == 'closed') {
+        if ($prInfo->isClosed()) {
             return $this->processClosed($name);
         }
         return $this->processOpen($name);


### PR DESCRIPTION
I factored `GitHubAPI` out of the GitHub provider so that I could refactor `WebAPI` out of that, and use it to build `BitbucketAPI`. This allows both the Bitbucket Repository provider and the Bitbucket CI Pipelines provider to use the same API object to talk to the BitBucket API.  This will also afford us the ability to re-use some of the paged API request code in BitBucket + GitLab, e.g. when searching for pull requests.

The GitLabProvider still needs to be refactored to follow suit.