### PR TITLE
Update Circle API calls to prevent 500 error

### DIFF
--- a/src/ServiceProviders/CIProviders/CircleCI/CircleCIProvider.php
+++ b/src/ServiceProviders/CIProviders/CircleCI/CircleCIProvider.php
@@ -156,6 +156,7 @@ class CircleCIProvider implements CIProvider, LoggerAwareInterface, PrivateKeyRe
         $headers = [
             'Content-Type' => 'application/json',
             'User-Agent' => ProviderEnvironment::USER_AGENT,
+            'Accept' => 'application/json',
         ];
 
         $client = new \GuzzleHttp\Client();


### PR DESCRIPTION
Recently, we started seeing CircleCI responding with a 500 error to all API requests. This was only happening for requests made directly via Build Tools -- using a proxy such as Charles and then copying the captured request to command line curl worked fine. Turns out, CLI curl adds an `Accept` header to the request (which is not present via Build Tools). The [docs](https://circleci.com/docs/api/#accept-header) seem to indicate that an `Accept` header is not required...but reality seems to prove otherwise. Let's add an `Accept: application/json` header for CircleCI as we don't need extra whitespace or comments in the response anyway.