### PR TITLE
Add temporary environment variable detection to GitLab URL detection

### DIFF
--- a/src/API/GitLab/GitLabAPI.php
+++ b/src/API/GitLab/GitLabAPI.php
@@ -53,6 +53,15 @@ class GitLabAPI extends WebAPI
 
     public static function determineGitLabUrl(Config $config)
     {
+        // Robo's Config object in combination with Terminus does not properly expand
+        // environment variable configurations for nested items. This temporary env
+        // detection can be removed once resolved. This can be ovserved by using
+        // `terminus self:config:dump` from a local environment with the configuration
+        // set via config.yml and from a CI environment with the below env variable set.
+        if ($preservedGitLabUrl = getenv('TERMINUS_BUILD_TOOLS_PROVIDER_GIT_GITLAB_URL'))
+        {
+            return $preservedGitLabUrl;
+        }
         return $config->get(self::GITLAB_CONFIG_PATH, self::GITLAB_URL_DEFAULT);
     }
 


### PR DESCRIPTION
Due to a bug in the way Terminus pulls environment configuration values with Robo, we (unfortunately) need to add manual detection.