### PR TITLE
Support for custom build asset messages.

### DIFF
--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -701,7 +701,8 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         $site_env_id,
         $multidev = '',
         $repositoryDir = '',
-        $label = '')
+        $label = '',
+        $message = '')
     {
         list($site, $env) = $this->getSiteEnv($site_env_id);
         $env_id = $env->getName();
@@ -710,6 +711,10 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         $env_label = $multidev;
         if (!empty($label)) {
             $env_label = $label;
+        }
+
+        if (empty($message)) {
+            $message = "Build assets for $env_label.";
         }
 
         if (empty($repositoryDir)) {
@@ -778,7 +783,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         $this->passthru("git -C $repositoryDir add --force -A .");
 
         // Now that everything is ready, commit the build artifacts.
-        $this->passthru("git -C $repositoryDir commit -q -m 'Build assets for $env_label.'");
+        $this->passthru("git -C $repositoryDir commit -q -m '$message'");
 
         // If the environment does exist, then we need to be in git mode
         // to push the branch up to the existing multidev site.

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -783,7 +783,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         $this->passthru("git -C $repositoryDir add --force -A .");
 
         // Now that everything is ready, commit the build artifacts.
-        $this->passthru("git -C $repositoryDir commit -q -m '$message'");
+        $this->passthru($this->interpolate("git -C {repositoryDir} commit -q -m [[message]]", ['repositoryDir' => $repositoryDir, 'message' => $message]));
 
         // If the environment does exist, then we need to be in git mode
         // to push the branch up to the existing multidev site.

--- a/src/Commands/EnvCreateCommand.php
+++ b/src/Commands/EnvCreateCommand.php
@@ -42,6 +42,7 @@ class EnvCreateCommand extends BuildToolsBase
      * @option clone-content Run terminus env:clone-content if the environment is re-used
      * @option db-only Only clone the database when runing env:clone-content
      * @option notify Do not use this deprecated option. Previously used for a build notify command, currently ignored.
+     * @option message Commit message to include when committing assets to Pantheon
      */
     public function createBuildEnv(
         $site_env_id,
@@ -50,7 +51,8 @@ class EnvCreateCommand extends BuildToolsBase
             'label' => '',
             'clone-content' => false,
             'notify' => '',
-            'db-only' => false
+            'db-only' => false,
+            'message' => '',
         ])
     {
         list($site, $env) = $this->getSiteEnv($site_env_id);

--- a/src/Commands/EnvPushCommand.php
+++ b/src/Commands/EnvPushCommand.php
@@ -43,8 +43,9 @@ class EnvPushCommand extends BuildToolsBase
         $repositoryDir = '',
         $options = [
           'label' => '',
+          'message' => '',
         ])
     {
-        return $this->pushCodeToPantheon($site_env_id, '', $repositoryDir, $options['label']);
+        return $this->pushCodeToPantheon($site_env_id, '', $repositoryDir, $options['label'], $options['message']);
     }
 }


### PR DESCRIPTION
Resolves #161 

By default, Build Tools will create an additional commit when pushing to Pantheon with a commit message of "Build assets for <environment>". Prior commit history from the external repository provider is retained as the "Build assets" command is just an additional commit.

Using `build:env:create` or `build:env:push` you can now include an optional `--message` flag to override the commit message on the build commit.

<img width="866" alt="image" src="https://user-images.githubusercontent.com/1789427/55280968-8e5d5780-5303-11e9-9736-c3939bd00d5e.png">

Should the `--message` option not be used, the existing functionality will be used including the "copying" of commit messages from the external provider to Pantheon and the "Build assets for <environment>"