### PR TITLE
WIP - Option to omit --force param

### DIFF
--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -815,7 +815,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
 
         // Push the branch to Pantheon
         $preCommitTime = time();
-        $this->passthru("git -C $repositoryDir push --force -q pantheon $branch");
+        $this->passthru("git -C $repositoryDir push -q pantheon $branch");
 
         // If the environment already existed, then we risk encountering
         // a race condition, because the 'git push' above will fire off

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -815,7 +815,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
 
         // Push the branch to Pantheon
         $preCommitTime = time();
-        $this->passthru("git -C $repositoryDir push -q pantheon $branch");
+        $this->passthru("git -C $repositoryDir push --force -q pantheon $branch");
 
         // If the environment already existed, then we risk encountering
         // a race condition, because the 'git push' above will fire off

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -801,7 +801,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         // any unwanted files prior to the build step (e.g. after a clean
         // checkout in a CI environment.)
         $this->passthru("git -C $repositoryDir checkout -B $branch");
-        $this->passthru("git -C $repositoryDir add --force -A .");
+        $this->passthru("git -C $repositoryDir add -A .");
 
         // Now that everything is ready, commit the build artifacts.
         $this->passthru($this->interpolate("git -C {repositoryDir} commit -q -m [[message]]", ['repositoryDir' => $repositoryDir, 'message' => $message]));
@@ -815,7 +815,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
 
         // Push the branch to Pantheon
         $preCommitTime = time();
-        $this->passthru("git -C $repositoryDir push --force -q pantheon $branch");
+        $this->passthru("git -C $repositoryDir push -q pantheon $branch");
 
         // If the environment already existed, then we risk encountering
         // a race condition, because the 'git push' above will fire off

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -762,7 +762,8 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
 
         // Add a remote named 'pantheon' to point at the Pantheon site's git repository.
         // Skip this step if the remote is already there (e.g. due to CI service caching).
-        $this->addPantheonRemote($env, $repositoryDir);
+        $dev_env = $site->getEnvironments()->get('dev');
+        $this->addPantheonRemote($dev_env, $repositoryDir);
         // $this->passthru("git -C $repositoryDir fetch pantheon");
 
         // Record the metadata for this build

--- a/src/Commands/EnvCreateCommand.php
+++ b/src/Commands/EnvCreateCommand.php
@@ -87,7 +87,7 @@ class EnvCreateCommand extends BuildToolsBase
             $doNotify = true;
         }
 
-        $metadata = $this->pushCodeToPantheon($site_env_id, $multidev, '', $env_label);
+        $metadata = $this->pushCodeToPantheon($site_env_id, $multidev, '', $env_label, $options['message']);
 
         // Create a new environment for this test.
         if (!$environmentExists && !$createBeforePush) {


### PR DESCRIPTION
I'm working on a CircleCI Orb that should first be beneficial for the use case of having the same repo on GitHub and Pantheon (without a build step). Using the `--force` option on git commands seems out of step with that use case.

I'm making this branch so that I can pull it in to some of my personal repos. If it goes well I will add a cli option to toggle `--force` off.