### PR TITLE
allow build:env:create to clone test, live, etc

### DIFF
--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -726,6 +726,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         $message = '')
     {
         list($site, $env) = $this->getSiteEnv($site_env_id);
+        $dev_env = $site->getEnvironments()->get('dev');
         $env_id = $env->getName();
         $multidev = empty($multidev) ? $env_id : $multidev;
         $branch = ($multidev == 'dev') ? 'master' : $multidev;
@@ -762,7 +763,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
 
         // Add a remote named 'pantheon' to point at the Pantheon site's git repository.
         // Skip this step if the remote is already there (e.g. due to CI service caching).
-        $this->addPantheonRemote($env, $repositoryDir);
+        $this->addPantheonRemote($dev_env, $repositoryDir);
         // $this->passthru("git -C $repositoryDir fetch pantheon");
 
         // Record the metadata for this build


### PR DESCRIPTION
This commit fixes an error with `build:env:create` which currently depends on the source environment being the `dev` environment (since it is the only one that has a `git_url`).

This is fixed by always using the `dev` environment for `BuildToolsBase ::addPantheonRemote()` since that is the only logical entry point to the codebase of a site. A new branch will still be created for the multidev environment as expected.