### PR TITLE
Allow setting the region when creating a site

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Additional options are available to further customize the build:project:create c
 | --admin-email    | The email address to use for the admin |
 | --ci             | The CI provider to use. Defaults to "circleci" |
 | --git            | The git repository provider to use. Defaults to "github" |
+| --region         | The region to create the site in |
 
 See `terminus help build:project:create` for more information.
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Additional options are available to further customize the build:project:create c
 | --admin-email    | The email address to use for the admin |
 | --ci             | The CI provider to use. Defaults to "circleci" |
 | --git            | The git repository provider to use. Defaults to "github" |
-| --region         | The region to create the site in |
+| --region         | The region to create the site in. See [the Pantheon regions documentation](https://pantheon.io/docs/regions#create-a-new-site-in-a-specific-region-using-terminus) for details. |
 
 See `terminus help build:project:create` for more information.
 

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -466,7 +466,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
     // TODO: if we could look up the commandfile for
     // Pantheon\Terminus\Commands\Site\CreateCommand,
     // then we could just call its 'create' method
-    public function siteCreate($site_name, $label, $upstream_id, $options = ['org' => null,])
+    public function siteCreate($site_name, $label, $upstream_id, $options = ['org' => null, 'region' => null,])
     {
         if ($this->sites()->nameIsTaken($site_name)) {
             throw new TerminusException('The site name {site_name} is already taken.', compact('site_name'));
@@ -485,6 +485,11 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         if (!empty($org_id = $options['org'])) {
             $org = $user->getOrgMemberships()->get($org_id)->getOrganization();
             $workflow_options['organization_id'] = $org->id;
+        }
+
+        // Add the site region.
+        if (!empty($region = $options['region'])) {
+            $workflow_options['preferred_zone'] = $region;
         }
 
         // Create the site

--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -208,6 +208,7 @@ class ProjectCreateCommand extends BuildToolsBase
             'keep' => false,
             'ci' => '',
             'git' => 'github',
+            'region' => '',
         ])
     {
         $this->warnAboutOldPhp();
@@ -218,6 +219,7 @@ class ProjectCreateCommand extends BuildToolsBase
         $team = $options['team'];
         $label = $options['label'];
         $stability = $options['stability'];
+        $region = $options['region'];
 
         // Provide default values for other optional variables.
         if (empty($label)) {
@@ -295,13 +297,13 @@ class ProjectCreateCommand extends BuildToolsBase
             // Create a Pantheon site
             ->progressMessage('Create Pantheon site {site}', ['site' => $site_name])
             ->addCode(
-                function ($state) use ($site_name, $label, $team, $target, $siteDir) {
+                function ($state) use ($site_name, $label, $team, $target, $siteDir, $region) {
                     // Look up our upstream.
                     $upstream = $this->autodetectUpstream($siteDir);
 
                     $this->log()->notice('About to create Pantheon site {site} in {team} with upstream {upstream}', ['site' => $site_name, 'team' => $team, 'upstream' => $upstream]);
 
-                    $site = $this->siteCreate($site_name, $label, $upstream, ['org' => $team]);
+                    $site = $this->siteCreate($site_name, $label, $upstream, ['org' => $team, 'region' => $region]);
 
                     $siteInfo = $site->serialize();
                     $site_uuid = $siteInfo['id'];


### PR DESCRIPTION
With the new region options available in Pantheon.  I needed to start creating my sites in the CA region and so I needed this plugin to allow passing the option --region to the terminus site:create command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pantheon-systems/terminus-build-tools-plugin/225)
<!-- Reviewable:end -->
