### PR TITLE
Add support for creating scheduled GitLab Pipeline

### DIFF
--- a/src/API/GitLab/GitLabAPITrait.php
+++ b/src/API/GitLab/GitLabAPITrait.php
@@ -71,7 +71,7 @@ trait GitLabAPITrait
    */
   public function credentialRequests()
   {
-    $instructions = "Please generate a GitLab personal access token by visiting the page:\n\n    https://" . $this->getGitLabUrl() . "/profile/personal_access_tokens\n\n For more information, see:\n\n    https://" . $this->getGitLabUrl() . "/help/user/profile/personal_access_tokens.md.\n\n Give it the 'api' (required) scopes.";
+    $instructions = "Please generate a GitLab personal access token by visiting the page:\n\n    https://" . $this->getGitLabUrl() . "/profile/personal_access_tokens\n\n For more information, see:\n\n    https://" . $this->getGitLabUrl() . "/help/user/profile/personal_access_tokens.md.\n\n Give it the 'api', 'read_repository', and 'write_repository' (required) scopes.";
 
     $validation_message = 'GitLab authentication tokens should be 20-character strings containing only the letters a-z and digits (0-9). Please enter your token again.';
 

--- a/src/ServiceProviders/CIProviders/GitLabCI/GitLabCIProvider.php
+++ b/src/ServiceProviders/CIProviders/GitLabCI/GitLabCIProvider.php
@@ -138,8 +138,16 @@ class GitLabCIProvider extends BaseCIProvider implements CIProvider, LoggerAware
         }
     }
 
-    public function startTesting(CIState $ci_env) {
-        // Do nothing...it starts automatically.
+    public function startTesting(CIState $ci_env)
+    {
+        // We use this opportunity to set up our scheduled job for automated updates.
+        $uri = $this->apiUri($ci_env, 'pipeline_schedules');
+        $data = [
+            'ref' => 'master',
+            'description' => 'Automated composer updates.',
+            'cron' => '0 4 * * *'
+        ];
+        $this->api()->request($uri, $data);
     }
 
     public function addPrivateKey(CIState $ci_env, $privateKey)


### PR DESCRIPTION
Part of the resolution for https://github.com/pantheon-systems/example-wordpress-composer/issues/134.

GitLab requires scheduled pipeline jobs to be completed via the API or via the UI. This adds support for setup via the "start testing" step of Build Tools. Scheduled Pipelines in GitLab run on a branch and act as if someone had triggered a CI run for that branch.

Note: This is, in many ways, dependent on https://github.com/pantheon-systems/example-wordpress-composer/pull/158 which should be merged and replicated on Drops 7 & 8 before fully merging this.