### PR TITLE
add tokenKey method for BitBucket

### DIFF
--- a/src/API/Bitbucket/BitbucketAPITrait.php
+++ b/src/API/Bitbucket/BitbucketAPITrait.php
@@ -45,6 +45,11 @@ trait BitbucketAPITrait
         return $api;
     }
 
+    public function tokenKey()
+    {
+        return BitbucketAPI::BITBUCKET_PASS;
+    }
+
     public function hasToken($key = false)
     {
         $repositoryEnvironment = $this->getEnvironment();


### PR DESCRIPTION
Required for Quicksilver Pushback.

Originally https://github.com/pantheon-systems/terminus-build-tools-plugin/pull/229