### PR TITLE
update phpspec/prophecy version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "symfony/polyfill-ctype": "v1.11.0",
         "symfony/yaml": "v3.4.26",
         "webmozart/assert": "1.4.0",
-        "phpspec/prophecy": "1.8.0"
+        "phpspec/prophecy": "1.8.1"
     },
     "scripts": {
         "unit-test": "./vendor/bin/phpunit --bootstrap ./vendor/autoload.php tests/*"


### PR DESCRIPTION
Hi! As a fix semi-related to the trouble me and my co-workers have been having in #236, the latest error we're getting from the CircleCI build is:

```
The plugin pantheon-systems/terminus-build-tools-plugin has installed the p  
  roject phpspec/prophecy: 1.8.0, but Terminus has installed phpspec/prophecy  
  : 1.8.1. To resolve this, try running 'composer update' in both the plugin   
  directory, and the terminus directory. 
```

I believe updating `composer.json` so `phpspec/prophecy` as at `1.8.1` would solve this issue.