### PR TITLE
Fix PHP notices when interacting with BitBucket API data

### DIFF
--- a/src/API/Bitbucket/BitbucketAPI.php
+++ b/src/API/Bitbucket/BitbucketAPI.php
@@ -63,4 +63,10 @@ class BitbucketAPI extends WebAPI
     {
         return null;
     }
+
+    protected function getResultData($res)
+    {
+        $resultData = json_decode($res->getBody(), true);
+        return isset( $resultData['values'] ) ? $resultData['values'] : [];
+    }
 }

--- a/src/API/Bitbucket/BitbucketAPI.php
+++ b/src/API/Bitbucket/BitbucketAPI.php
@@ -6,6 +6,7 @@ use Pantheon\TerminusBuildTools\API\WebAPI;
 use Pantheon\TerminusBuildTools\API\WebAPIInterface;
 use Pantheon\TerminusBuildTools\ServiceProviders\ProviderEnvironment;
 use Pantheon\TerminusBuildTools\ServiceProviders\ServiceTokenStorage;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 
@@ -64,7 +65,7 @@ class BitbucketAPI extends WebAPI
         return null;
     }
 
-    protected function getResultData($res)
+    protected function getResultData(ResponseInterface $res)
     {
         $resultData = json_decode($res->getBody(), true);
         return isset( $resultData['values'] ) ? $resultData['values'] : [];

--- a/src/API/WebAPI.php
+++ b/src/API/WebAPI.php
@@ -49,7 +49,7 @@ abstract class WebAPI implements WebAPIInterface, LoggerAwareInterface
         $queryParams = $this->alterPagedRequestQueryParams($queryParams);
         $res = $this->sendRequest($uri, $queryParams, 'GET');
 
-        $resultData = json_decode($res->getBody(), true);
+        $resultData = $this->getResultData($res);
         $httpCode = $res->getStatusCode();
 
         // Remember all of the collected data in $accumulatedData
@@ -161,5 +161,10 @@ abstract class WebAPI implements WebAPIInterface, LoggerAwareInterface
             }
         }
         return TRUE;
+    }
+
+    protected function getResultData($res)
+    {
+        return json_decode($res->getBody(), true);
     }
 }

--- a/src/API/WebAPI.php
+++ b/src/API/WebAPI.php
@@ -5,6 +5,7 @@ namespace Pantheon\TerminusBuildTools\API;
 use Pantheon\TerminusBuildTools\API\WebAPI;
 use Pantheon\TerminusBuildTools\ServiceProviders\ProviderEnvironment;
 use Pantheon\TerminusBuildTools\ServiceProviders\ServiceTokenStorage;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Pantheon\Terminus\Exceptions\TerminusException;
@@ -73,7 +74,7 @@ abstract class WebAPI implements WebAPIInterface, LoggerAwareInterface
                     // $uri already has $queryParams, as altered in the $pager_info
                     $res = $this->sendRequest($uri, [], 'GET');
                     $httpCode = $res->getStatusCode();
-                    $resultData = json_decode($res->getBody(), true);
+                    $resultData = $this->getResultData($res);
                     $isDone = !$this->checkPagedCallback($resultData, $callback);
 
                     if (!is_null($resultData))
@@ -163,7 +164,7 @@ abstract class WebAPI implements WebAPIInterface, LoggerAwareInterface
         return TRUE;
     }
 
-    protected function getResultData($res)
+    protected function getResultData(ResponseInterface $res)
     {
         return json_decode($res->getBody(), true);
     }

--- a/src/ServiceProviders/RepositoryProviders/Bitbucket/BitbucketProvider.php
+++ b/src/ServiceProviders/RepositoryProviders/Bitbucket/BitbucketProvider.php
@@ -132,7 +132,7 @@ class BitbucketProvider extends BaseGitProvider implements GitProvider, LoggerAw
                 $branch_name = $item['source']['branch']['name'];
                 return [$pr_number, $branch_name];
             },
-            $data['values']
+            $data
         ), 1, 0);
 
         return $branchList;


### PR DESCRIPTION
BitBucket's API response is shaped differently than GitHub and GitLab.
The values themselves are nested in a `values` key.

Fixes #261 