### PR TITLE
Update `BitbucketAPI` to handle API data pagination

### DIFF
--- a/src/API/Bitbucket/BitbucketAPI.php
+++ b/src/API/Bitbucket/BitbucketAPI.php
@@ -47,22 +47,33 @@ class BitbucketAPI extends WebAPI
 
     protected function isPagedResponse(ResponseInterface $res)
     {
-        return true;
+        $responseBody = json_decode($res->getBody(), true);
+        if (!empty($responseBody['next']) || ! empty($responseBody['previous'])) {
+            return true;
+        }
+        return false;
     }
 
     protected function getPagerInfo(ResponseInterface $res)
     {
-        return [];
+        $responseBody = json_decode($res->getBody(), true);
+        $pagerInfo = [];
+        foreach (['next', 'previous'] as $type) {
+            if (isset($responseBody[$type])) {
+                $pagerInfo[$type] = $responseBody[$type];
+            }
+        }
+        return $pagerInfo;
     }
 
     protected function isLastPage($page_link, $pager_info)
     {
-        return true;
+        return empty($pager_info['next']);
     }
 
     protected function getNextPageUri($pager_info)
     {
-        return null;
+        return !empty($pager_info['next']) ? $pager_info['next'] : false;
     }
 
     protected function getResultData(ResponseInterface $res)

--- a/src/API/Bitbucket/BitbucketAPI.php
+++ b/src/API/Bitbucket/BitbucketAPI.php
@@ -73,7 +73,7 @@ class BitbucketAPI extends WebAPI
 
     protected function getNextPageUri($pager_info)
     {
-        return !empty($pager_info['next']) ? $pager_info['next'] : false;
+        return !empty($pager_info['next']) ? $pager_info['next'] : NULL;
     }
 
     protected function getResultData(ResponseInterface $res)


### PR DESCRIPTION
BitBucket includes the `next` parameter in its response, not as a
header.

Depends on #263, #264 
Fixes #253 