### PR TITLE
TEST: Allow git providers to provide build secrets.

### DIFF
--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -345,9 +345,7 @@ class ProjectCreateCommand extends BuildToolsBase
             ->progressmessage('Set build secrets')
             ->addCode(
                 function ($state) use ($site_name, $siteDir) {
-                    $secretValues = [
-                        'token' => $this->git_provider->token($this->git_provider->tokenKey())
-                    ];
+                    $secretValues = $this->git_provider->getSecretValues();
                     $this->writeSecrets("{$site_name}.dev", $secretValues, false, 'tokens.json');
                    // Remember the initial commit sha
                     $state['initial_commit'] = $this->getHeadCommit($siteDir);

--- a/src/Commands/ProjectRepairCommand.php
+++ b/src/Commands/ProjectRepairCommand.php
@@ -162,10 +162,8 @@ class ProjectRepairCommand extends BuildToolsBase
 
             ->addCode(
                 function ($state) use ($site_name) {
-                    $secretValues = [
-                        'token' => $this->git_provider->token($this->git_provider->tokenKey())
-                    ];
-                    $this->writeSecrets("{$site_name}.dev", $secretValues, false, 'tokens.json');
+                  $secretValues = $this->git_provider->getSecretValues();
+                  $this->writeSecrets("{$site_name}.dev", $secretValues, false, 'tokens.json');
                 }
             );
 

--- a/src/ServiceProviders/RepositoryProviders/BaseGitProvider.php
+++ b/src/ServiceProviders/RepositoryProviders/BaseGitProvider.php
@@ -72,4 +72,10 @@ abstract class BaseGitProvider
     {
     }
 
+    public function getSecretValues() {
+      return [
+        'token' => $this->token($this->tokenKey())
+      ];
+    }
+
 }

--- a/src/ServiceProviders/RepositoryProviders/Bitbucket/BitbucketProvider.php
+++ b/src/ServiceProviders/RepositoryProviders/Bitbucket/BitbucketProvider.php
@@ -143,4 +143,12 @@ class BitbucketProvider extends BaseGitProvider implements GitProvider, LoggerAw
         $isClosed = ($data['state'] != 'OPEN');
         return new PullRequestInfo($data['id'], $isClosed, $data['source']['branch']['name']);
     }
+
+    public function getSecretValues() {
+      return parent::getSecretValues() + [
+        'user' => $this->getBitBucketUser(),
+        'password' => $this->getBitBucketPassword(),
+      ];
+    }
+
 }

--- a/src/ServiceProviders/RepositoryProviders/GitProvider.php
+++ b/src/ServiceProviders/RepositoryProviders/GitProvider.php
@@ -87,4 +87,11 @@ interface GitProvider extends ProviderInterface
      */
     public function alterBuildMetadata(&$buildMetadata);
 
+    /**
+     * Return an associative array of values to be written to tokens.json build secrets.
+     *
+     * @return array
+     */
+    public function getSecretValues();
+
 }


### PR DESCRIPTION
From #268. Allowing git providers to specify their own build secrets addresses issues like https://github.com/pantheon-systems/quicksilver-pushback/issues/12 where different providers expect different credentials.

Adds `GitProvider::getSecretValues` interface method, and default implementation to match existing behavior.