### PR TITLE
Force url in build metadata to https for BitBucket

### DIFF
--- a/src/ServiceProviders/RepositoryProviders/Bitbucket/BitbucketProvider.php
+++ b/src/ServiceProviders/RepositoryProviders/Bitbucket/BitbucketProvider.php
@@ -151,4 +151,10 @@ class BitbucketProvider extends BaseGitProvider implements GitProvider, LoggerAw
       ];
     }
 
+    public function alterBuildMetadata(&$buildMetadata) {
+        parent::alterBuildMetadata($buildMetadata);
+        // Force https in the URL
+        $buildMetadata['url'] = str_replace('http','https', $buildMetadata['url']);
+    }
+
 }


### PR DESCRIPTION
See https://github.com/pantheon-systems/quicksilver-pushback/issues/12