### PR TITLE
Add scheduled CLU task creation to Bitbucket provider startTesting task

### DIFF
--- a/src/ServiceProviders/CIProviders/BitbucketPipelines/BitbucketPipelinesProvider.php
+++ b/src/ServiceProviders/CIProviders/BitbucketPipelines/BitbucketPipelinesProvider.php
@@ -109,7 +109,29 @@ class BitbucketPipelinesProvider extends BaseCIProvider implements CIProvider, L
         // Temporary: catch and eat errors without stopping the command
         try
         {
+            // Enable Pipelines for the project.
             $this->api()->request("$repoApiUrl/pipelines_config", $data, 'PUT');
+        } catch (\Exception $e) {
+            $this->logger->error($e->getMessage());
+        }
+
+        // @TODO: verify that the custom "clu" task exists in yml first?
+        $data = [
+          'enabled' => true,
+          'cron_pattern' => '0 0 4 * * ? *',
+          'target' => [
+            'type' => 'pipeline_ref_target',
+            'ref_type' => 'branch',
+            'ref_name' => 'master',
+            'selector' => [
+              'type' => 'custom',
+              'pattern' => 'clu'
+            ]
+          ]
+        ];
+        try {
+            // Enable CLU scheduled task.
+            $this->api()->request("$repoApiUrl/pipelines_config/schedules/", $data, 'POST');
         } catch (\Exception $e) {
             $this->logger->error($e->getMessage());
         }


### PR DESCRIPTION
Depends on the `clu` task getting defined in bitbucket-pipelines.yml 
https://github.com/pantheon-systems/example-drops-8-composer/pull/289
