### PR TITLE
Addresses #290 by allowing BitBucket repos to assign a project

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ Note: It is important to specify the name of your agency organization via the `-
 
 The `build:project:create` command supports services in the following combination: 
 
-| Git Host  | CI Service |
-| --------- | ---------- |
-| GitHub    | CircleCI   |
-| GitLab    | GitLabCI   |
-| BitBucket | CircleCI   |
+| Git Host  | CI Service          |
+| --------- | ------------------- |
+| GitHub    | CircleCI            |
+| GitLab    | GitLab CI           |
+| BitBucket | BitBucket Pipelines |
 
 ### Starting a new GitLab Project
 
@@ -138,9 +138,15 @@ Additional options are available to further customize the `build:project:create`
  | --git              | The git repository provider to use. Defaults to "github" |
  | --visibility       | The visibility of the project. Defaults to "public". Use "public" or "private" for GitHub and "public", "private", or "internal" for GitLab |
  | --region           | The region to create the site in. See [the Pantheon regions documentation](https://pantheon.io/docs/regions#create-a-new-site-in-a-specific-region-using-terminus) for details. |
- 
+
+The `--extra` option is also used to pass provider specific information. The are passed in the format of `--extra='key=value'`. Each additional extra option should be passed on its own by using `--extra` more than once. Valid `extra` options are:
+
+| Key | Description | Example |
+| --- | ----------- | ------- |
+| bitbucket-project | The BitBucket project name or key to associate the repository with. `org` must also be declared. | --extra='bitbucket-project=Test BB Project' |
+
 See `terminus help build:project:create` for more information.
- 
+
 ### build:project:repair
  
 The `build:project:repair` command is used to repair projects that were created with the Build Tools plugin. This is useful for rotating credentials, such as provider authentication tokens.

--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -138,7 +138,6 @@ class ProjectCreateCommand extends BuildToolsBase
         if ($team != '-') {
             $input->setOption('team', $team);
         }
-
     }
 
     /**
@@ -282,8 +281,7 @@ class ProjectCreateCommand extends BuildToolsBase
           $this->log()->notice('Verified SSH connection to Git provider');
         }
 
-        // Grant providers opportunity to add their own interactions just before
-        // creating project assets.
+        // Grant service providers opportunity to add their own interactions just before creating project assets.
         $this->providerManager()->addInteractions($this->input(), $this->output());
 
         // Pull down the source project

--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -462,13 +462,17 @@ class ProjectCreateCommand extends BuildToolsBase
                 function ($state) use ($ci_env, $siteDir, $use_ssh) {
                     $repositoryAttributes = $ci_env->getState('repository');
                     $this->git_provider->pushRepository($siteDir, $repositoryAttributes->projectId(), $use_ssh);
-                })
+                });
 
-            // Tell the CI server to start testing our project
-            ->progressMessage('Beginning CI testing')
-            ->taskCIStartTesting()
-                ->provider($this->ci_provider)
-                ->environment($ci_env);
+        // Sleep for 10 seconds to allow the CI
+        // provider to recognize the project
+        sleep(10);
+
+        // Tell the CI server to start testing our project
+        $builder->progressMessage('Beginning CI testing')
+        ->taskCIStartTesting()
+            ->provider($this->ci_provider)
+            ->environment($ci_env);
 
 
         // If the user specified --keep, then clone a local copy of the project

--- a/src/ServiceProviders/AdditionalInteractionsInterface.php
+++ b/src/ServiceProviders/AdditionalInteractionsInterface.php
@@ -5,14 +5,15 @@ namespace Pantheon\TerminusBuildTools\ServiceProviders;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-interface AdditionalInteractionsInterface {
+interface AdditionalInteractionsInterface
+{
 
-  /**
-   * Perform interactions to collect provider-specific options.
-   *
-   * @param \Symfony\Component\Console\Input\InputInterface $input
-   * @param \Symfony\Component\Console\Output\OutputInterface $output
-   */
-  public function addInteractions(InputInterface $input, OutputInterface $output);
+    /**
+     * Perform interactions to collect provider-specific options.
+     *
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     */
+    public function addInteractions(InputInterface $input, OutputInterface $output);
 
 }

--- a/src/ServiceProviders/AdditionalInteractionsInterface.php
+++ b/src/ServiceProviders/AdditionalInteractionsInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Pantheon\TerminusBuildTools\ServiceProviders;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+interface AdditionalInteractionsInterface {
+
+  /**
+   * Perform interactions to collect provider-specific options.
+   *
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   */
+  public function addInteractions(InputInterface $input, OutputInterface $output);
+
+}

--- a/src/ServiceProviders/ProviderManager.php
+++ b/src/ServiceProviders/ProviderManager.php
@@ -7,6 +7,8 @@ use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Robo\Config\Config;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class ProviderManager implements LoggerAwareInterface
 {
@@ -130,4 +132,16 @@ class ProviderManager implements LoggerAwareInterface
             }
         }
     }
+
+    public function addInteractions(InputInterface $input, OutputInterface $output)
+    {
+        foreach ($this->providers as $provider) {
+          if ($provider instanceof AdditionalInteractionsInterface) {
+            // Allow service providers to perform additional interactions to
+            // collect provider-specific options, e.g. Bitbucket project.
+            $provider->addInteractions($input, $output);
+          }
+        }
+    }
+
 }

--- a/src/ServiceProviders/ProviderManager.php
+++ b/src/ServiceProviders/ProviderManager.php
@@ -136,11 +136,11 @@ class ProviderManager implements LoggerAwareInterface
     public function addInteractions(InputInterface $input, OutputInterface $output)
     {
         foreach ($this->providers as $provider) {
-          if ($provider instanceof AdditionalInteractionsInterface) {
-            // Allow service providers to perform additional interactions to
-            // collect provider-specific options, e.g. Bitbucket project.
-            $provider->addInteractions($input, $output);
-          }
+            if ($provider instanceof AdditionalInteractionsInterface) {
+                // Allow service providers to perform additional interactions to
+                // collect provider-specific options, e.g. Bitbucket project.
+                $provider->addInteractions($input, $output);
+            }
         }
     }
 

--- a/src/ServiceProviders/RepositoryProviders/Bitbucket/BitbucketProvider.php
+++ b/src/ServiceProviders/RepositoryProviders/Bitbucket/BitbucketProvider.php
@@ -233,8 +233,10 @@ class BitbucketProvider extends BaseGitProvider implements GitProvider, LoggerAw
         $extras = $input->getOption('extra');
         if (!empty($extras['bitbucket-project'])) {
             $project_uuid = $this->getProjectUUID($extras['bitbucket-project'], $org);
-            $this->project = $project_uuid;
-            return;
+            if (false !== $project_uuid) {
+                $this->project = $project_uuid;
+                return;
+            }
         }
         if (!$projects = $this->getProjectOptions($org)) {
             return;

--- a/src/ServiceProviders/RepositoryProviders/Bitbucket/BitbucketProvider.php
+++ b/src/ServiceProviders/RepositoryProviders/Bitbucket/BitbucketProvider.php
@@ -177,7 +177,11 @@ class BitbucketProvider extends BaseGitProvider implements GitProvider, LoggerAw
         }
         $options = [];
         foreach ($projects['values'] as $value) {
-            $options[] = $value['name'] . ' (' . $value['key'] . ')';
+            $options[] = [
+                "name" => $value['name'],
+                "key" => $value['key'],
+                "uuid" => $value['uuid'],
+            ];
         }
         return $options;
     }
@@ -199,11 +203,19 @@ class BitbucketProvider extends BaseGitProvider implements GitProvider, LoggerAw
             return;
         }
         $default = '(Do not assign a project)';
-        $projects[] = $default;
+        $project_options = [
+            $default
+        ];
+        foreach ( $projects as $project ) {
+            $project_options[] = $project['name'] . ' (' . $project['key'] . ')';
+        }
         $io = new SymfonyStyle($input, $output);
-        $project = $io->choice('Select a project for the new repository', $projects, $default);
-        if ($project != $default) {
-            $this->project = $project;
+        $project = $io->choice('Select a project for the new repository', $project_options, $default);
+        // Remove the default value
+        array_shift( $project_options );
+        $project_array_key = array_search( $project, $project_options, true );
+        if ($project != $default && FALSE !== $project_array_key ) {
+            $this->project = $projects[$project_array_key]['uuid'];
         }
     }
 

--- a/src/ServiceProviders/RepositoryProviders/Bitbucket/BitbucketProvider.php
+++ b/src/ServiceProviders/RepositoryProviders/Bitbucket/BitbucketProvider.php
@@ -171,12 +171,12 @@ class BitbucketProvider extends BaseGitProvider implements GitProvider, LoggerAw
     protected function getProjectOptions($org)
     {
         // Trailing slash is REQUIRED on this resource. See https://jira.atlassian.com/browse/BCLOUD-17211
-        $projects = $this->api()->request("teams/$org/projects/");
-        if (empty($projects) || empty($projects['values'])) {
+        $projects = $this->api()->pagedRequest("teams/$org/projects/");
+        if (empty($projects)) {
             return [];
         }
         $options = [];
-        foreach ($projects['values'] as $value) {
+        foreach ($projects as $value) {
             $options[] = [
                 "name" => $value['name'],
                 "key" => $value['key'],

--- a/src/ServiceProviders/RepositoryProviders/Bitbucket/BitbucketProvider.php
+++ b/src/ServiceProviders/RepositoryProviders/Bitbucket/BitbucketProvider.php
@@ -168,23 +168,25 @@ class BitbucketProvider extends BaseGitProvider implements GitProvider, LoggerAw
       ];
     }
 
-    protected function getProjectOptions($org) {
-      // Trailing slash is REQUIRED on this resource. See https://jira.atlassian.com/browse/BCLOUD-17211
-      $projects = $this->api()->request("teams/$org/projects/");
-      if (empty($projects) || empty($projects['values'])) {
-        return [];
-      }
-      $options = [];
-      foreach ($projects['values'] as $value) {
-        $options[] = $value['name'] . ' (' . $value['key'] . ')';
-      }
-      return $options;
+    protected function getProjectOptions($org)
+    {
+        // Trailing slash is REQUIRED on this resource. See https://jira.atlassian.com/browse/BCLOUD-17211
+        $projects = $this->api()->request("teams/$org/projects/");
+        if (empty($projects) || empty($projects['values'])) {
+            return [];
+        }
+        $options = [];
+        foreach ($projects['values'] as $value) {
+            $options[] = $value['name'] . ' (' . $value['key'] . ')';
+        }
+        return $options;
     }
 
     /**
      * Add repository to a project, if bitbucket org supports it.
      */
-    public function addInteractions(InputInterface $input, OutputInterface $output) {
+    public function addInteractions(InputInterface $input, OutputInterface $output)
+    {
         if (!$org = $input->getOption('org')) {
             return;
         }

--- a/src/ServiceProviders/RepositoryProviders/Bitbucket/BitbucketProvider.php
+++ b/src/ServiceProviders/RepositoryProviders/Bitbucket/BitbucketProvider.php
@@ -50,12 +50,14 @@ class BitbucketProvider extends BaseGitProvider implements GitProvider, LoggerAw
 
         // Create a Bitbucket repository
         $this->logger->notice('Creating repository {repo}', ['repo' => $target_project]);
-        $postData = [];
+        $postData = [
+            'scm' => 'git'
+        ];
         if ($visibility != 'public') {
           $postData['is_private'] = TRUE;
         }
         if (!empty($this->project)) {
-          $postData['project']['key'] = $this->project;
+          $postData['project']['uuid'] = $this->project;
         }
         $result = $this->api()->request("repositories/$target_project", $postData, 'PUT');
 


### PR DESCRIPTION
- Extension of #294
- Add "extra" option to `build:project:create` command, to allow additional arbitrary option inputs
- Create `AdditionalInteractionsInterface` to allow service providers opportunity to collect additional options