### PR TITLE
Added support for changing the admin username

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Additional options are available to further customize the `build:project:create`
  | --test-site-name   | The name to use when installing the test site |
  | --admin-password   | The password to use for the admin when installing the test site |
  | --admin-email      | The email address to use for the admin |
+ | --admin-username   | The username to use for the admin |
  | --stability        | The stability to use with composer when creating the project (defaults to dev) |
  | --keep             | The ability to keep a project repository cloned after your project is created |
  | --use-ssh          | The ability to perform the initial git push to the repository provider over SSH instead of HTTPS |

--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -183,6 +183,7 @@ class ProjectCreateCommand extends BuildToolsBase
      * @option email email address to place in ssh-key
      * @option test-site-name The name to use when installing the test site.
      * @option admin-email The email address to use for the CMS admin.
+     * @option admin-username The username to use for the CMS admin.
      * @option admin-password The password to use for the CMS admin when installing the test site.
      * @option stability Minimum allowed stability for template project.
      * @option git Specify a git provider. Options are github (default), gitlab, and bitbucket.
@@ -207,6 +208,7 @@ class ProjectCreateCommand extends BuildToolsBase
             'test-site-name' => '',
             'admin-password' => '',
             'admin-email' => '',
+            'admin-username' => '',
             'stability' => '',
             'env' => [],
             'preserve-local-repository' => false,
@@ -420,7 +422,7 @@ class ProjectCreateCommand extends BuildToolsBase
                     // Install the site.
                     $site_install_options = [
                         'account-mail' => $siteAttributes->adminEmail(),
-                        'account-name' => 'admin',
+                        'account-name' => $siteAttributes->adminUsername(),
                         'account-pass' => $siteAttributes->adminPassword(),
                         'site-mail' => $siteAttributes->adminEmail(),
                         'site-name' => $siteAttributes->testSiteName(),

--- a/src/Commands/ProjectRepairCommand.php
+++ b/src/Commands/ProjectRepairCommand.php
@@ -110,6 +110,7 @@ class ProjectRepairCommand extends BuildToolsBase
             'test-site-name' => '',
             'admin-password' => '',
             'admin-email' => '',
+            'admin-username' => '',
             'env' => [],
             'ci' => '',
         ])

--- a/src/ServiceProviders/SiteProviders/PantheonProvider.php
+++ b/src/ServiceProviders/SiteProviders/PantheonProvider.php
@@ -98,7 +98,7 @@ class PantheonProvider implements SiteProvider, CredentialClientInterface, Publi
         $adminEmailRequest = (new CredentialRequest('ADMIN_EMAIL'))
             ->setRequired(false);
 
-        $adminEmailRequest = (new CredentialRequest('ADMIN_USERNAME'))
+        $adminUsernameRequest = (new CredentialRequest('ADMIN_USERNAME'))
             ->setRequired(false);
 
         $adminPasswordRequest = (new CredentialRequest('ADMIN_PASSWORD'))

--- a/src/ServiceProviders/SiteProviders/PantheonProvider.php
+++ b/src/ServiceProviders/SiteProviders/PantheonProvider.php
@@ -98,6 +98,9 @@ class PantheonProvider implements SiteProvider, CredentialClientInterface, Publi
         $adminEmailRequest = (new CredentialRequest('ADMIN_EMAIL'))
             ->setRequired(false);
 
+        $adminEmailRequest = (new CredentialRequest('ADMIN_USERNAME'))
+            ->setRequired(false);
+
         $adminPasswordRequest = (new CredentialRequest('ADMIN_PASSWORD'))
             ->setInstructions(self::PASSWORD_INSTRUCTIONS)
             ->setPrompt(self::PASSWORD_PROMPT)
@@ -128,6 +131,7 @@ class PantheonProvider implements SiteProvider, CredentialClientInterface, Publi
         $test_site_name = $credentials_provider->fetch('TEST_SITE_NAME');
         $git_email = $credentials_provider->fetch('GIT_USER_EMAIL');
         $admin_email = $credentials_provider->fetch('ADMIN_EMAIL');
+        $admin_username = $credentials_provider->fetch('ADMIN_USERNAME');
         $adminPassword = $credentials_provider->fetch('ADMIN_PASSWORD');
 
         // We should always have a site name by the time we get here,
@@ -151,6 +155,11 @@ class PantheonProvider implements SiteProvider, CredentialClientInterface, Publi
             $admin_email = $git_email;
         }
 
+        // If no admin username was provided, use 'admin'
+        if (empty($admin_username)) {
+            $admin_username = 'admin';
+        }
+
         // If no admin password was provided, generate a random one
         if (empty($adminPassword)) {
             $adminPassword = mt_rand();
@@ -171,6 +180,7 @@ class PantheonProvider implements SiteProvider, CredentialClientInterface, Publi
             ->setTestSiteName($test_site_name)
             ->setAdminPassword($adminPassword)
             ->setAdminEmail($admin_email)
+            ->setAdminUsername($admin_username)
             ->setGitEmail($git_email);
 
         // Assign COMPOSER_AUTH if defined in config.yml or environment.

--- a/src/ServiceProviders/SiteProviders/SiteEnvironment.php
+++ b/src/ServiceProviders/SiteProviders/SiteEnvironment.php
@@ -11,10 +11,10 @@ class SiteEnvironment extends ProviderEnvironment
         return $this['TERMINUS_SITE'];
     }
 
-    public function setSiteName($siteName)
+    public function setSiteName($site_name)
     {
         $this->makeVariableValuePublic('TERMINUS_SITE');
-        $this['TERMINUS_SITE'] = $siteName;
+        $this['TERMINUS_SITE'] = $site_name;
         return $this;
     }
 
@@ -23,9 +23,9 @@ class SiteEnvironment extends ProviderEnvironment
         return $this['TERMINUS_TOKEN'];
     }
 
-    public function setSiteToken($siteName)
+    public function setSiteToken($site_token)
     {
-        $this['TERMINUS_TOKEN'] = $siteName;
+        $this['TERMINUS_TOKEN'] = $site_token;
         return $this;
     }
 
@@ -34,10 +34,10 @@ class SiteEnvironment extends ProviderEnvironment
         return $this['TEST_SITE_NAME'];
     }
 
-    public function setTestSiteName($siteName)
+    public function setTestSiteName($test_site_name)
     {
         $this->makeVariableValuePublic('TEST_SITE_NAME');
-        $this['TEST_SITE_NAME'] = $siteName;
+        $this['TEST_SITE_NAME'] = $test_site_name;
         return $this;
     }
 
@@ -46,9 +46,9 @@ class SiteEnvironment extends ProviderEnvironment
         return $this['ADMIN_PASSWORD'];
     }
 
-    public function setAdminPassword($siteName)
+    public function setAdminPassword($admin_password)
     {
-        $this['ADMIN_PASSWORD'] = $siteName;
+        $this['ADMIN_PASSWORD'] = $admin_password;
         return $this;
     }
 
@@ -57,9 +57,20 @@ class SiteEnvironment extends ProviderEnvironment
         return $this['ADMIN_EMAIL'];
     }
 
-    public function setAdminEmail($siteName)
+    public function setAdminEmail($admin_email)
     {
-        $this['ADMIN_EMAIL'] = $siteName;
+        $this['ADMIN_EMAIL'] = $admin_email;
+        return $this;
+    }
+
+    public function adminUsername()
+    {
+        return $this['ADMIN_USERNAME'];
+    }
+
+    public function setAdminUsername($admin_username)
+    {
+        $this['ADMIN_USERNAME'] = $admin_username;
         return $this;
     }
 
@@ -68,9 +79,9 @@ class SiteEnvironment extends ProviderEnvironment
         return $this['GIT_EMAIL'];
     }
 
-    public function setGitEmail($siteName)
+    public function setGitEmail($git_email)
     {
-        $this['GIT_EMAIL'] = $siteName;
+        $this['GIT_EMAIL'] = $git_email;
         return $this;
     }
 


### PR DESCRIPTION
We tend to avoid using "admin" as a username so I've added support for providing a custom admin username via the build:project:create option with the key "admin-username".

I also cleaned up the getters and setters as the parameters were named incorrectly.