### PR TITLE
Repurpose 'notify' option to allow callers to suppress VCS notification

### DIFF
--- a/src/Commands/EnvCreateCommand.php
+++ b/src/Commands/EnvCreateCommand.php
@@ -26,7 +26,7 @@ class EnvCreateCommand extends BuildToolsBase
      * @option label What to name the environment in commit comments
      * @option clone-content Run terminus env:clone-content if the environment is re-used
      * @option db-only Only clone the database when runing env:clone-content
-     * @option notify If TRUE, post a comment on commit or PR. Otherwise, skip notification. Defaults to TRUE.
+     * @option notify To suppress comment on commit or PR, use "--notify=0". Defaults to true.
      * @option message Commit message to include when committing assets to Pantheon
      * @option pr-id Post notification comment to a specific PR instead of the commit hash.
      */

--- a/src/Commands/EnvCreateCommand.php
+++ b/src/Commands/EnvCreateCommand.php
@@ -26,7 +26,7 @@ class EnvCreateCommand extends BuildToolsBase
      * @option label What to name the environment in commit comments
      * @option clone-content Run terminus env:clone-content if the environment is re-used
      * @option db-only Only clone the database when runing env:clone-content
-     * @option notify Do not use this deprecated option. Previously used for a build notify command, currently ignored.
+     * @option notify If TRUE, post a comment on commit or PR. Otherwise, skip notification. Defaults to TRUE.
      * @option message Commit message to include when committing assets to Pantheon
      * @option pr-id Post notification comment to a specific PR instead of the commit hash.
      */
@@ -36,7 +36,7 @@ class EnvCreateCommand extends BuildToolsBase
         $options = [
             'label' => '',
             'clone-content' => false,
-            'notify' => '',
+            'notify' => true,
             'db-only' => false,
             'message' => '',
             'pr-id' =>  '',
@@ -135,7 +135,7 @@ class EnvCreateCommand extends BuildToolsBase
         // TODO: Push to repo provider
 
         // Run notification command
-        if ($doNotify == true) {
+        if ($doNotify == true && $options['notify']) {
             $site_name = $site->getName();
             $project = $this->projectFromRemoteUrl($metadata['url']);
             $dashboard_url = "https://dashboard.pantheon.io/sites/{$site_id}#{$multidev}";


### PR DESCRIPTION
Addresses https://github.com/pantheon-systems/terminus-build-tools-plugin/issues/327 by allowing callers to skip the default notification.

- "notify" has been a deprecated option for [2+ years](https://github.com/pantheon-systems/terminus-build-tools-plugin/pull/108), seems safe to repurpose now
- Maintains BC with old implementations relying on prior behavior