### PR TITLE
Support WP in ProjectCreateCommand install

### DIFF
--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -559,9 +559,10 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
             'account-pass' => '',
             'site-mail' => '',
             'site-name' => ''
-        ])
+        ],
+        $upstream = 'drupal')
     {
-        $command_template = $this->getInstallCommandTemplate($composer_json);
+        $command_template = $this->getInstallCommandTemplate($composer_json, $upstream);
         return $this->runCommandTemplateOnRemoteEnv($site_env_id, $command_template, "Install site", $site_install_options);
     }
 
@@ -670,15 +671,15 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
     /**
      * Determine the command to use to install the site.
      */
-    protected function getInstallCommandTemplate($composer_json)
+    protected function getInstallCommandTemplate($composer_json, $upstream)
     {
         if (isset($composer_json['extra']['build-env']['install-cms'])) {
             return $composer_json['extra']['build-env']['install-cms'];
         }
-        // TODO: Select a different default template based on the cms type (Drupal or WordPress).
-        $defaultTemplate = 'drush site-install --yes --account-mail={account-mail} --account-name={account-name} --account-pass={account-pass} --site-mail={site-mail} --site-name={site-name}';
-
-        return $defaultTemplate;
+        if ($upstream == 'empty-wordpress') {
+            return 'wp core install --url={site-url} --title="{site-name}" --admin_user={account-name} --admin_password={account-pass} --admin_email={account-mail}';
+        }
+        return 'drush site-install --yes --account-mail={account-mail} --account-name={account-name} --account-pass={account-pass} --site-mail={site-mail} --site-name={site-name}';
     }
 
     /**

--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -271,6 +271,9 @@ class ProjectCreateCommand extends BuildToolsBase
         $this->log()->notice('Create a local working copy of {src}', ['src' => $source]);
         $siteDir = $this->createFromSource($source, $target, $stability, $options);
 
+        // Look up our upstream.
+        $upstream = $this->autodetectUpstream($siteDir);
+
         // Restore COMPOSER_AUTH if necessary.
         if (!is_null($backupAuth)) {
             putenv('COMPOSER_AUTH=' . $backupAuth);
@@ -309,9 +312,7 @@ class ProjectCreateCommand extends BuildToolsBase
             // Create a Pantheon site
             ->progressMessage('Create Pantheon site {site}', ['site' => $site_name])
             ->addCode(
-                function ($state) use ($site_name, $label, $team, $target, $siteDir, $region) {
-                    // Look up our upstream.
-                    $upstream = $this->autodetectUpstream($siteDir);
+                function ($state) use ($site_name, $label, $team, $target, $siteDir, $region, $upstream) {
 
                     $this->log()->notice('About to create Pantheon site {site} in {team} with upstream {upstream}', ['site' => $site_name, 'team' => $team, 'upstream' => $upstream]);
 
@@ -413,7 +414,7 @@ class ProjectCreateCommand extends BuildToolsBase
             // Note that this also commits the configuration to the repository.
             ->progressMessage('Install CMS on Pantheon site {site}', ['site' => $site_name])
             ->addCode(
-                function ($state) use ($ci_env, $site_name, $siteDir) {
+                function ($state) use ($ci_env, $site_name, $siteDir, $upstream) {
                     $siteAttributes = $ci_env->getState('site');
                     $composer_json = $this->getComposerJson($siteDir);
 
@@ -426,7 +427,7 @@ class ProjectCreateCommand extends BuildToolsBase
                         'site-name' => $siteAttributes->testSiteName(),
                         'site-url' => "https://dev-{$site_name}.pantheonsite.io"
                     ];
-                    $this->doInstallSite("{$site_name}.dev", $composer_json, $site_install_options);
+                    $this->doInstallSite("{$site_name}.dev", $composer_json, $site_install_options, $upstream);
 
                     // Before any tests have been configured, export the
                     // configuration set up by the installer.


### PR DESCRIPTION
`build:project:create` command doesn't work for WP - attempt to use Drush.
And had a rather suspicious line: 
`// TODO: Select a different default template based on the cms type (Drupal or WordPress).`

PR implements that using the existing detection method.