### PR TITLE
Add self info command for build tools.

### DIFF
--- a/src/API/GitHub/GitHubAPITrait.php
+++ b/src/API/GitHub/GitHubAPITrait.php
@@ -101,7 +101,7 @@ trait GitHubAPITrait
         $tokenKey = $this->tokenKey();
         $token = $credentials_provider->fetch($tokenKey);
         if (!$token) {
-            throw new \Exception('Could not determine authentication token for GitHub serivces. Please set ' . $tokenKey);
+            throw new \Exception('Could not determine authentication token for GitHub services. Please set ' . $tokenKey);
         }
         $this->setToken($token);
     }

--- a/src/API/GitLab/GitLabAPITrait.php
+++ b/src/API/GitLab/GitLabAPITrait.php
@@ -106,7 +106,7 @@ trait GitLabAPITrait
     $tokenKey = $this->tokenKey();
     $token = $credentials_provider->fetch($tokenKey);
     if (!$token) {
-      throw new \Exception('Could not determine authentication token for GitLab serivces. Please set ' . $tokenKey);
+      throw new \Exception('Could not determine authentication token for GitLab services. Please set ' . $tokenKey);
     }
     $this->setToken($token);
   }

--- a/src/Commands/SelfInfoCommand.php
+++ b/src/Commands/SelfInfoCommand.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Terminus Plugin that contain a collection of commands useful during
+ * the build step on a [Pantheon](https://www.pantheon.io) site that uses
+ * a Git PR workflow.
+ *
+ * See README.md for usage information.
+ */
+
+namespace Pantheon\TerminusBuildTools\Commands;
+
+use Consolidation\OutputFormatters\StructuredData\PropertyList;
+use Pantheon\TerminusBuildTools\ServiceProviders\CIProviders\CIProvider;
+use Pantheon\TerminusBuildTools\ServiceProviders\RepositoryProviders\BaseGitProvider;
+use Pantheon\TerminusBuildTools\ServiceProviders\RepositoryProviders\GitHub\GitHubProvider;
+use Pantheon\TerminusBuildTools\ServiceProviders\RepositoryProviders\GitProvider;
+use Pantheon\TerminusBuildTools\ServiceProviders\SiteProviders\SiteProvider;
+
+/**
+ * Self Info Command
+ */
+class SelfInfoCommand extends BuildToolsBase
+{
+
+    /**
+     * Show information about the Terminus Build Tools local environment.
+     *
+     * @field-labels
+     *     build_tools_directory: Build Tools Installation Directory
+     *     supported_providers: Providers with Tokens On Your System
+     *     releases: Releases
+     * @return PropertyList
+     *
+     * @command build:self:info
+     */
+    public function info()
+    {
+        $buildToolsDirectory = str_replace('/src/Commands', '', dirname(__FILE__));
+
+        $providerManager = $this->providerManager();
+
+        $providers = $providerManager->availableProviders();
+        foreach ($providers as $provider) {
+            $providerClass = new \ReflectionClass($provider);
+            if ($providerClass->implementsInterface(GitProvider::class)) {
+                $this->createGitProvider($provider);
+            }
+            elseif ($providerClass->implementsInterface(CIProvider::class)) {
+                $this->createCIProvider($provider);
+            }
+            elseif ($providerClass->implementsInterface(SiteProvider::class)) {
+                $this->createSiteProvider($provider);
+            }
+        }
+
+        $supportedProviders = [];
+        foreach ($providerManager->getProviders() as $provider) {
+            $credentialRequests = $provider->credentialRequests();
+            foreach ($credentialRequests as $credentialRequest) {
+                $this->providerManager()->credentialManager()->addRequest($credentialRequest);
+                $provider->setCredentials($this->providerManager()->credentialManager());
+            }
+            $secretValues = $provider->getSecretValues();
+            $validProvider = TRUE;
+            foreach ($secretValues as $value) {
+                if (strlen($value) > 1) {
+                    continue;
+                }
+                else {
+                    $validProvider = FALSE;
+                }
+            }
+            if ($validProvider) {
+                $supportedProviders[] = $provider->getServiceName();
+            }
+        }
+
+        return new PropertyList([
+            'build_tools_directory' => $buildToolsDirectory,
+            'supported_providers' => implode(', ', $supportedProviders),
+            'releases' => 'https://github.com/pantheon-systems/terminus-build-tools-plugin/releases',
+        ]);
+    }
+}

--- a/src/Commands/SelfInfoCommand.php
+++ b/src/Commands/SelfInfoCommand.php
@@ -55,23 +55,29 @@ class SelfInfoCommand extends BuildToolsBase
 
         $supportedProviders = [];
         foreach ($providerManager->getProviders() as $provider) {
-            $credentialRequests = $provider->credentialRequests();
-            foreach ($credentialRequests as $credentialRequest) {
-                $this->providerManager()->credentialManager()->addRequest($credentialRequest);
-                $provider->setCredentials($this->providerManager()->credentialManager());
-            }
-            $secretValues = $provider->getSecretValues();
-            $validProvider = TRUE;
-            foreach ($secretValues as $value) {
-                if (strlen($value) > 1) {
-                    continue;
+            try {
+                $credentialRequests = $provider->credentialRequests();
+                foreach ($credentialRequests as $credentialRequest) {
+                    $this->providerManager()->credentialManager()->addRequest($credentialRequest);
+                    $provider->setCredentials($this->providerManager()->credentialManager());
                 }
-                else {
-                    $validProvider = FALSE;
+                $secretValues = $provider->getSecretValues();
+                $validProvider = TRUE;
+                foreach ($secretValues as $value) {
+                    if (strlen($value) > 1) {
+                        continue;
+                    }
+                    else {
+                        $validProvider = FALSE;
+                    }
+                }
+                if ($validProvider) {
+                    $supportedProviders[] = $provider->getServiceName();
                 }
             }
-            if ($validProvider) {
-                $supportedProviders[] = $provider->getServiceName();
+            catch (\Exception $e) {
+                // Some providers like to throw a fatal error if they don't have credentials.
+                // Catch it here and just keep oging, since they shouldn't be on our list anyway.
             }
         }
 

--- a/src/ServiceProviders/CIProviders/BaseCIProvider.php
+++ b/src/ServiceProviders/CIProviders/BaseCIProvider.php
@@ -51,4 +51,10 @@ abstract class BaseCIProvider
         }
         return $intersecting;
     }
+
+    public function getSecretValues() {
+        return [
+          'token' => $this->token()
+        ];
+    }
 }

--- a/src/ServiceProviders/ProviderEnvironment.php
+++ b/src/ServiceProviders/ProviderEnvironment.php
@@ -44,6 +44,9 @@ class ProviderEnvironment extends \ArrayObject implements ServiceTokenStorage
         if (!$key) {
             $key = $this->token_key;
         }
+        if (!isset($this[$key])) {
+            return NULL;
+        }
         return $this[$key];
     }
 

--- a/src/ServiceProviders/ProviderManager.php
+++ b/src/ServiceProviders/ProviderManager.php
@@ -22,7 +22,7 @@ class ProviderManager implements LoggerAwareInterface
         $this->config = $config;
     }
 
-    protected function availableProviders()
+    public function availableProviders()
     {
         return [
             '\Pantheon\TerminusBuildTools\ServiceProviders\CIProviders\CircleCI\CircleCIProvider',
@@ -92,7 +92,7 @@ class ProviderManager implements LoggerAwareInterface
         return $this->initializeProvider($provider);
     }
 
-    protected function initializeProvider($provider)
+    public function initializeProvider($provider)
     {
         if ($provider instanceof LoggerAwareInterface) {
             $provider->setLogger($this->logger);
@@ -129,5 +129,10 @@ class ProviderManager implements LoggerAwareInterface
                 $provider->setCredentials($this->credential_manager);
             }
         }
+    }
+
+    public function getProviders()
+    {
+        return $this->providers;
     }
 }

--- a/src/ServiceProviders/SiteProviders/PantheonProvider.php
+++ b/src/ServiceProviders/SiteProviders/PantheonProvider.php
@@ -221,4 +221,13 @@ class PantheonProvider implements SiteProvider, CredentialClientInterface, Publi
         // Add the public key to Pantheon.
         $this->session()->getUser()->getSSHKeys()->addKey($publicKey);
     }
+
+    /**
+     * Retrieves this providers tokens.
+     */
+    public function getSecretValues() {
+        return [
+          'token' => $this->machineToken
+        ];
+    }
 }


### PR DESCRIPTION
Resolves #288.

The command currently shows the directory where you have Build Tools installed, the providers that have tokens set up already, and where to find new releases.

```
terminus build:self:info
```