### PR TITLE
Adding an option for --no-git-force on build:env:create and build:env:push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs
 defaults: &defaults
   docker:
-    - image: quay.io/pantheon-public/php-ci:2.x
+    - image: quay.io/pantheon-public/php-ci:4.x
   working_directory: ~/terminus_build_tools_plugin
   environment:
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ The `build:env:create` command creates the specified multidev environment on the
  | --clone-content  | Clone the content from the dev environment to the new multidev environment |
  | --db-only        | When cloning content, whether to only clone the database (by default, both the database and files are cloned |
  | --message        | The commit message to use when committing the built assets to Pantheon |
+ | --no-git-force   | Set this flag to omit the --force flag from `git add` and `git push` |
  
 ### build:env:delete:ci
 
@@ -281,6 +282,7 @@ The `build:env:push` command pushes code in the current directory to an existing
  | ---------------- | ---------------- |
  | --label          | The name of the site when referred to in commit comments. |
  | --message        | The commit message to use when committing built code to Pantheon |
+ | --no-git-force   | Set this flag to omit the --force flag from `git add` and `git push` |
  
 ### build:project:info
  

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -728,7 +728,8 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         $multidev = '',
         $repositoryDir = '',
         $label = '',
-        $message = '')
+        $message = '',
+        $gitForce = FALSE)
     {
         list($site, $env) = $this->getSiteEnv($site_env_id);
         $dev_env = $site->getEnvironments()->get('dev');
@@ -807,7 +808,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         // any unwanted files prior to the build step (e.g. after a clean
         // checkout in a CI environment.)
         $this->passthru("git -C $repositoryDir checkout -B $branch");
-        if ($this->respectGitignore($repositoryDir)) {
+        if ($this->respectGitignore($repositoryDir) || $gitForce === FALSE) {
             // In "Integrated Composer" mode, we will not commit ignored files
             $this->passthru("git -C $repositoryDir add .");
         }
@@ -827,7 +828,8 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
 
         // Push the branch to Pantheon
         $preCommitTime = time();
-        $this->passthru("git -C $repositoryDir push --force -q pantheon $branch");
+        $forceFlag = $gitForce ? "--force" : "";
+        $this->passthru("git -C $repositoryDir push $forceFlag -q pantheon $branch");
 
         // If the environment already existed, then we risk encountering
         // a race condition, because the 'git push' above will fire off

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -729,7 +729,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         $repositoryDir = '',
         $label = '',
         $message = '',
-        $gitForce = FALSE)
+        $gitForce = TRUE)
     {
         list($site, $env) = $this->getSiteEnv($site_env_id);
         $dev_env = $site->getEnvironments()->get('dev');

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -808,7 +808,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         // any unwanted files prior to the build step (e.g. after a clean
         // checkout in a CI environment.)
         $this->passthru("git -C $repositoryDir checkout -B $branch");
-        if ($this->respectGitignore($repositoryDir) || $gitForce === FALSE) {
+        if ($this->respectGitignore($repositoryDir) || $gitForce == FALSE) {
             // In "Integrated Composer" mode, we will not commit ignored files
             $this->passthru("git -C $repositoryDir add .");
         }

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -729,7 +729,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         $repositoryDir = '',
         $label = '',
         $message = '',
-        $NoGitForce = FALSE)
+        $noGitForce = FALSE)
     {
         list($site, $env) = $this->getSiteEnv($site_env_id);
         $dev_env = $site->getEnvironments()->get('dev');
@@ -808,7 +808,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         // any unwanted files prior to the build step (e.g. after a clean
         // checkout in a CI environment.)
         $this->passthru("git -C $repositoryDir checkout -B $branch");
-        if ($this->respectGitignore($repositoryDir) || $NoGitForce === TRUE) {
+        if ($this->respectGitignore($repositoryDir) || $noGitForce === TRUE) {
             // In "Integrated Composer" mode, we will not commit ignored files
             $this->passthru("git -C $repositoryDir add .");
         }
@@ -828,7 +828,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
 
         // Push the branch to Pantheon
         $preCommitTime = time();
-        $forceFlag = $NoGitForce ? "" : "--force";
+        $forceFlag = $noGitForce ? "" : "--force";
         $this->passthru("git -C $repositoryDir push $forceFlag -q pantheon $branch");
 
         // If the environment already existed, then we risk encountering

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -729,7 +729,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         $repositoryDir = '',
         $label = '',
         $message = '',
-        $gitForce = TRUE)
+        $NoGitForce = FALSE)
     {
         list($site, $env) = $this->getSiteEnv($site_env_id);
         $dev_env = $site->getEnvironments()->get('dev');
@@ -808,7 +808,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         // any unwanted files prior to the build step (e.g. after a clean
         // checkout in a CI environment.)
         $this->passthru("git -C $repositoryDir checkout -B $branch");
-        if ($this->respectGitignore($repositoryDir) || $gitForce == FALSE) {
+        if ($this->respectGitignore($repositoryDir) || $NoGitForce === TRUE) {
             // In "Integrated Composer" mode, we will not commit ignored files
             $this->passthru("git -C $repositoryDir add .");
         }
@@ -828,7 +828,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
 
         // Push the branch to Pantheon
         $preCommitTime = time();
-        $forceFlag = $gitForce ? "--force" : "";
+        $forceFlag = $NoGitForce ? "" : "--force";
         $this->passthru("git -C $repositoryDir push $forceFlag -q pantheon $branch");
 
         // If the environment already existed, then we risk encountering

--- a/src/Commands/EnvCreateCommand.php
+++ b/src/Commands/EnvCreateCommand.php
@@ -29,6 +29,7 @@ class EnvCreateCommand extends BuildToolsBase
      * @option notify Do not use this deprecated option. Previously used for a build notify command, currently ignored.
      * @option message Commit message to include when committing assets to Pantheon
      * @option pr-id Post notification comment to a specific PR instead of the commit hash.
+     * @option no-git-force set this flag to omit the --force flag from 'git add' and 'git push'
      */
     public function createBuildEnv(
         $site_env_id,
@@ -40,6 +41,7 @@ class EnvCreateCommand extends BuildToolsBase
             'db-only' => false,
             'message' => '',
             'pr-id' =>  '',
+            'no-git-force' =>  false,
         ])
     {
         list($site, $env) = $this->getSiteEnv($site_env_id);
@@ -55,7 +57,7 @@ class EnvCreateCommand extends BuildToolsBase
         if ('dev' === $multidev) {
             $this->log()->notice('dev has been passed to the multidev option. Reverting to dev:env:push as dev is not a multidev environment.');
             // Run build:env:push.
-            $this->pushCodeToPantheon($site_env_id, $multidev, '', $env_label);
+            $this->pushCodeToPantheon($site_env_id, $multidev, '', $env_label, $options['message'], $options['git-force']);
             return;
         }
 
@@ -91,7 +93,7 @@ class EnvCreateCommand extends BuildToolsBase
             $doNotify = true;
         }
 
-        $metadata = $this->pushCodeToPantheon($site_env_id, $multidev, '', $env_label, $options['message']);
+        $metadata = $this->pushCodeToPantheon($site_env_id, $multidev, '', $env_label, $options['message'], $options['git-force']);
 
         // Create a new environment for this test.
         if (!$environmentExists && !$createBeforePush) {

--- a/src/Commands/EnvCreateCommand.php
+++ b/src/Commands/EnvCreateCommand.php
@@ -93,7 +93,7 @@ class EnvCreateCommand extends BuildToolsBase
             $doNotify = true;
         }
 
-        $metadata = $this->pushCodeToPantheon($site_env_id, $multidev, '', $env_label, $options['message'], $options['git-force']);
+        $metadata = $this->pushCodeToPantheon($site_env_id, $multidev, '', $env_label, $options['message'], $options['no-git-force']);
 
         // Create a new environment for this test.
         if (!$environmentExists && !$createBeforePush) {

--- a/src/Commands/EnvMergeCommand.php
+++ b/src/Commands/EnvMergeCommand.php
@@ -51,8 +51,7 @@ class EnvMergeCommand extends BuildToolsBase
 
         // Replace the entire contents of the master branch with the branch we just tested.
         $this->passthru('git fetch pantheon');
-        $forceFlag = $gitForce ? "--force" : "";
-        $this->passthru("git push $forceFlag -q pantheon pantheon/$env_id:master");
+        $this->passthru("git push --force -q pantheon pantheon/$env_id:master");
 
         // Wait for the dev environment to finish syncing after the merge.
         $this->waitForCodeSync($preCommitTime, $site, 'dev');

--- a/src/Commands/EnvMergeCommand.php
+++ b/src/Commands/EnvMergeCommand.php
@@ -51,7 +51,8 @@ class EnvMergeCommand extends BuildToolsBase
 
         // Replace the entire contents of the master branch with the branch we just tested.
         $this->passthru('git fetch pantheon');
-        $this->passthru("git push --force -q pantheon pantheon/$env_id:master");
+        $forceFlag = $gitForce ? "--force" : "";
+        $this->passthru("git push $forceFlag -q pantheon pantheon/$env_id:master");
 
         // Wait for the dev environment to finish syncing after the merge.
         $this->waitForCodeSync($preCommitTime, $site, 'dev');

--- a/src/Commands/EnvPushCommand.php
+++ b/src/Commands/EnvPushCommand.php
@@ -25,7 +25,6 @@ class EnvPushCommand extends BuildToolsBase
      * @option label What to name the environment in commit comments
      * @option message Commit message to include when committing assets to Pantheon
      * @option no-git-force set this flag to omit the --force flag from 'git add' and 'git push'
-     *
      */
     public function pushCode(
         $site_env_id,

--- a/src/Commands/EnvPushCommand.php
+++ b/src/Commands/EnvPushCommand.php
@@ -32,9 +32,9 @@ class EnvPushCommand extends BuildToolsBase
         $options = [
           'label' => '',
           'message' => '',
-          'no-git-force' =>  false,
+          'no-git-force' => FALSE,
         ])
     {
-        return $this->pushCodeToPantheon($site_env_id, '', $repositoryDir, $options['label'], $options['message'], $options['git-force']);
+        return $this->pushCodeToPantheon($site_env_id, '', $repositoryDir, $options['label'], $options['message'], $options['no-git-force']);
     }
 }

--- a/src/Commands/EnvPushCommand.php
+++ b/src/Commands/EnvPushCommand.php
@@ -22,6 +22,10 @@ class EnvPushCommand extends BuildToolsBase
      *
      * @param string $site_env_id Site and environment to push to. May be any dev or multidev environment.
      * @param string $repositoryDir Code to push. Defaults to cwd.
+     * @option label What to name the environment in commit comments
+     * @option message Commit message to include when committing assets to Pantheon
+     * @option no-git-force set this flag to omit the --force flag from 'git add' and 'git push'
+     *
      */
     public function pushCode(
         $site_env_id,
@@ -29,8 +33,9 @@ class EnvPushCommand extends BuildToolsBase
         $options = [
           'label' => '',
           'message' => '',
+          'no-git-force' =>  false,
         ])
     {
-        return $this->pushCodeToPantheon($site_env_id, '', $repositoryDir, $options['label'], $options['message']);
+        return $this->pushCodeToPantheon($site_env_id, '', $repositoryDir, $options['label'], $options['message'], $options['git-force']);
     }
 }


### PR DESCRIPTION
This PR is a replacement for https://github.com/pantheon-systems/terminus-build-tools-plugin/pull/202 which has been used by our CircleCI Orb for the last year and is far behind master. The motivation here is to be able to use the Build Tools with little, or no risk of a force push overwriting history.

To test this change, I [also made a PR on the orb to use this version of Build Tools](https://github.com/pantheon-systems/circleci-orb/pull/45).
I then used that version of the orb in [a build](https://app.circleci.com/pipelines/github/stevector/nerdologues-d8/347/workflows/ceb0a006-0568-40c7-a612-6afbe0f7719c/jobs/4271) on a [consumer of the Orb](https://github.com/stevector/nerdologues-d8/pull/366/commits/8516b20965dfa445cdabcefa331cf4aa7efc523c).

Here's a screenshot of the section of the build where add and push happened without `--force`
<img width="825" alt="Screen Shot 2020-06-08 at 8 58 26 PM" src="https://user-images.githubusercontent.com/211029/84097707-eb09d700-a9ca-11ea-860f-1723635c56f1.png">
