### PR TITLE
Update composer install step to stable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ PHP `7.2` or greater is recommended.
 
 ```
 mkdir -p ~/.terminus/plugins
-composer create-project --no-dev -d ~/.terminus/plugins pantheon-systems/terminus-build-tools-plugin:^2.0.0-beta17
+composer create-project --no-dev -d ~/.terminus/plugins pantheon-systems/terminus-build-tools-plugin:^2.0.0
 ```
 
 ### Installing Build Tools 1.x:


### PR DESCRIPTION
I noticed the install snippet was still referencing the last pre-release (beta-17) instead of the 2.0.0 stable release.