### PR TITLE
BUGS-3249: Increase workflow timeout and add better logging

### DIFF
--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -997,14 +997,14 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         $this->waitForWorkflow($startTime, $site, $env_name);
     }
 
-    protected function waitForWorkflow($startTime, $site, $env_name, $expectedWorkflowDescription = '', $maxWaitInSeconds = 60)
+    protected function waitForWorkflow($startTime, $site, $env_name, $expectedWorkflowDescription = '', $maxWaitInSeconds = 180)
     {
         if (empty($expectedWorkflowDescription)) {
             $expectedWorkflowDescription = "Sync code on \"$env_name\"";
         }
 
         $startWaiting = time();
-        while(time() - $startWaiting < $maxWaitInSeconds) {
+        while(true) {
             $workflow = $this->getLatestWorkflow($site);
             $workflowCreationTime = $workflow->get('created_at');
             $workflowDescription = $workflow->get('description');
@@ -1012,6 +1012,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
             if (($workflowCreationTime > $startTime) && ($expectedWorkflowDescription == $workflowDescription)) {
                 $this->log()->notice("Workflow '{current}' {status}.", ['current' => $workflowDescription, 'status' => $workflow->getStatus(), ]);
                 if ($workflow->isSuccessful()) {
+                    $this->log()->notice("Workflow succeeded");
                     return;
                 }
             }
@@ -1020,6 +1021,11 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
             }
             // Wait a bit, then spin some more
             sleep(5);
+
+            if (time() - $startWaiting >= $maxWaitInSeconds) {
+                $this->log()->warning("Waited '{max}' seconds, giving up waiting for workflow to finish", ['max' => $maxWaitInSeconds]);
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
Pantheon workflows can take longer than 60 seconds to complete, so let's bump up the timeout.

Also, we should add better logging around this.

Success after this change:
```
 [notice] Workflow 'Sync code on "dev"' running.
 [notice] Workflow 'Sync code on "dev"' succeeded.
 [notice] Workflow succeeded
```

Timeout after this change:
```
 [notice] Workflow 'Sync code on "dev"' running.
 [warning] Waited '2' seconds, giving up waiting for workflow to finish
```