### PR TITLE
ISSUE-374: Updated the GitHub regex to support their new personal access token format

### DIFF
--- a/src/API/GitHub/GitHubAPITrait.php
+++ b/src/API/GitHub/GitHubAPITrait.php
@@ -72,7 +72,7 @@ trait GitHubAPITrait
         $githubTokenRequest = (new CredentialRequest($this->tokenKey()))
             ->setInstructions($instructions)
             ->setPrompt($prompt)
-            ->setValidateRegEx('#^[0-9a-fA-F]{40}$#')
+            ->setValidateRegEx('#^[0-9a-zA-Z_]{40}$#')
             ->setValidationErrorMessage($validation_message)
             ->setValidationCallbackErrorMessage($could_not_authorize)
             ->setValidateFn(


### PR DESCRIPTION
Addresses the issue documented here:
https://github.com/pantheon-systems/terminus-build-tools-plugin/issues/374