### PR TITLE
Fix branch name method to avoid infinite recursion

### DIFF
--- a/src/API/PullRequestInfo.php
+++ b/src/API/PullRequestInfo.php
@@ -30,6 +30,6 @@ class PullRequestInfo
 
     public function branchName()
     {
-        return $this->branchName();
+        return $this->branchName;
     }
 }


### PR DESCRIPTION
Fixes the `branchName` method in PullRequestInfo class to avoid infinite recursion. 