### PR TITLE
[CMS-145] [CMS-146] Add template repository option to project create command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ export TERMINUS_BUILD_TOOLS_COMPOSER_AUTH=json_encoded_string
 
 or in ~/.terminus/config.yml file under build-tools.composer-auth.
 
-You can find more info about [composer repositories](https://getcomposer.org/doc/05-repositories.md) and [private packages](https://getcomposer.org/doc/articles/handling-private-packages.md) in the official [composer documentation](https://getcomposer.org/doc/).
+You can find more info about [composer repositories](https://getcomposer.org/doc/05-repositories.md), [private packages](https://getcomposer.org/doc/articles/handling-private-packages.md), [cli authentication](https://getcomposer.org/doc/03-cli.md#composer-auth) and [authentication methods](https://getcomposer.org/doc/articles/authentication-for-private-packages.md) in the official [composer documentation](https://getcomposer.org/doc/).
  
 ### build:project:repair
  

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Additional options are available to further customize the `build:project:create`
  | --git                 | The git repository provider to use. Defaults to "github" |
  | --visibility          | The visibility of the project. Defaults to "public". Use "public" or "private" for GitHub and "public", "private", or "internal" for GitLab |
  | --region              | The region to create the site in. See [the Pantheon regions documentation](https://pantheon.io/docs/regions#create-a-new-site-in-a-specific-region-using-terminus) for details. |
- | --composer-repository | Private composer repository to download template. |
+ | --template-repository | Private composer repository to download template or git url if no composer repository. |
  
 See `terminus help build:project:create` for more information.
 
@@ -152,6 +152,8 @@ export TERMINUS_BUILD_TOOLS_COMPOSER_AUTH=json_encoded_string
 or in ~/.terminus/config.yml file under build-tools.composer-auth.
 
 You can find more info about [composer repositories](https://getcomposer.org/doc/05-repositories.md), [private packages](https://getcomposer.org/doc/articles/handling-private-packages.md), [cli authentication](https://getcomposer.org/doc/03-cli.md#composer-auth) and [authentication methods](https://getcomposer.org/doc/articles/authentication-for-private-packages.md) in the official [composer documentation](https://getcomposer.org/doc/).
+
+If you want to use a git repository as template, it should include a composer.json file and you should have access to it from your terminal. For the template name, you should use the project name in the template composer.json file.
  
 ### build:project:repair
  

--- a/README.md
+++ b/README.md
@@ -121,26 +121,37 @@ The `build:project:create` command is used to initialize projects within the Git
 
 Additional options are available to further customize the `build:project:create` command:
  
- | Option             | Description    |
- | ------------------ | -------------- |
- | --pantheon-site    | The name to use for the Pantheon site (defaults to the name of the Git site) | 
- | --team             | The Pantheon team to associate the site with |
- | --org              | The Git organization to place the repository in (defaults to authenticated user) |
- | --label            | The friendly name to use for the Pantheon site (defaults to the name of the Git site) |
- | --email            | The git user email address to use when committing build results |
- | --test-site-name   | The name to use when installing the test site |
- | --admin-password   | The password to use for the admin when installing the test site |
- | --admin-email      | The email address to use for the admin |
- | --admin-username   | The username to use for the admin |
- | --stability        | The stability to use with composer when creating the project (defaults to dev) |
- | --keep             | The ability to keep a project repository cloned after your project is created |
- | --use-ssh          | The ability to perform the initial git push to the repository provider over SSH instead of HTTPS |
- | --ci               | The CI provider to use. Defaults to "circleci" |
- | --git              | The git repository provider to use. Defaults to "github" |
- | --visibility       | The visibility of the project. Defaults to "public". Use "public" or "private" for GitHub and "public", "private", or "internal" for GitLab |
- | --region           | The region to create the site in. See [the Pantheon regions documentation](https://pantheon.io/docs/regions#create-a-new-site-in-a-specific-region-using-terminus) for details. |
+ | Option                | Description    |
+ | --------------------- | -------------- |
+ | --pantheon-site       | The name to use for the Pantheon site (defaults to the name of the Git site) |
+ | --team                | The Pantheon team to associate the site with |
+ | --org                 | The Git organization to place the repository in (defaults to authenticated user) |
+ | --label               | The friendly name to use for the Pantheon site (defaults to the name of the Git site) |
+ | --email               | The git user email address to use when committing build results |
+ | --test-site-name      | The name to use when installing the test site |
+ | --admin-password      | The password to use for the admin when installing the test site |
+ | --admin-email         | The email address to use for the admin |
+ | --admin-username      | The username to use for the admin |
+ | --stability           | The stability to use with composer when creating the project (defaults to dev) |
+ | --keep                | The ability to keep a project repository cloned after your project is created |
+ | --use-ssh             | The ability to perform the initial git push to the repository provider over SSH instead of HTTPS |
+ | --ci                  | The CI provider to use. Defaults to "circleci" |
+ | --git                 | The git repository provider to use. Defaults to "github" |
+ | --visibility          | The visibility of the project. Defaults to "public". Use "public" or "private" for GitHub and "public", "private", or "internal" for GitLab |
+ | --region              | The region to create the site in. See [the Pantheon regions documentation](https://pantheon.io/docs/regions#create-a-new-site-in-a-specific-region-using-terminus) for details. |
+ | --composer-repository | Private composer repository to download template. |
  
 See `terminus help build:project:create` for more information.
+
+Note that if you want to use a private composer repository, you should provide the credentials like this:
+
+```
+export TERMINUS_BUILD_TOOLS_COMPOSER_AUTH=json_encoded_string
+```
+
+or in ~/.terminus/config.yml file under build-tools.composer-auth.
+
+You can find more info about [composer repositories](https://getcomposer.org/doc/05-repositories.md) and [private packages](https://getcomposer.org/doc/articles/handling-private-packages.md) in the official [composer documentation](https://getcomposer.org/doc/).
  
 ### build:project:repair
  

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Additional options are available to further customize the `build:project:create`
  | --git                 | The git repository provider to use. Defaults to "github" |
  | --visibility          | The visibility of the project. Defaults to "public". Use "public" or "private" for GitHub and "public", "private", or "internal" for GitLab |
  | --region              | The region to create the site in. See [the Pantheon regions documentation](https://pantheon.io/docs/regions#create-a-new-site-in-a-specific-region-using-terminus) for details. |
- | --template-repository | Private composer repository to download template or git url if no composer repository. |
+ | --template-repository | Private composer repository to download template or git url if using the expanded version when no composer repository. |
  
 See `terminus help build:project:create` for more information.
 
@@ -153,7 +153,7 @@ or in ~/.terminus/config.yml file under build-tools.composer-auth.
 
 You can find more info about [composer repositories](https://getcomposer.org/doc/05-repositories.md), [private packages](https://getcomposer.org/doc/articles/handling-private-packages.md), [cli authentication](https://getcomposer.org/doc/03-cli.md#composer-auth) and [authentication methods](https://getcomposer.org/doc/articles/authentication-for-private-packages.md) in the official [composer documentation](https://getcomposer.org/doc/).
 
-If you want to use a git repository as template, it should include a composer.json file and you should have access to it from your terminal. For the template name, you should use the project name in the template composer.json file.
+If you want to use a git repository as template, it should include a composer.json file and you should have access to it from your terminal. For the template name, you could use the git repo url and this command will get the right project name.
  
 ### build:project:repair
  

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -388,7 +388,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
             return $this->useExistingSourceDirectory($source, $options['preserve-local-repository']);
         }
         else {
-            return $this->createFromSourceProject($source, $target, $stability, $options['composer-repository']);
+            return $this->createFromSourceProject($source, $target, $stability, $options['composer-repository'], $options['template-git-url']);
         }
     }
 
@@ -410,7 +410,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
     /**
      * Use composer create-project to create a new local copy of the source project.
      */
-    protected function createFromSourceProject($source, $target, $stability = '', $composer_repository = '')
+    protected function createFromSourceProject($source, $target, $stability = '', $composer_repository = '', $template_git_url = '')
     {
         $source_project = $this->sourceProjectFromSource($source);
 
@@ -431,6 +431,10 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
 
         if ($composer_repository) {
             $repository = ' --repository=' . $composer_repository;
+        }
+
+        if ($template_git_url) {
+            $repository = ' --repository="{\"url\": \"' . $template_git_url . '\", \"type\": \"vcs\"}"';
         }
 
         $this->passthru("composer create-project --working-dir=$tmpsitedir $repository $source $target -n $stability_flag");

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -388,7 +388,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
             return $this->useExistingSourceDirectory($source, $options['preserve-local-repository']);
         }
         else {
-            return $this->createFromSourceProject($source, $target, $stability, $options['composer-repository'], $options['template-git-url']);
+            return $this->createFromSourceProject($source, $target, $stability, $options['template-repository']);
         }
     }
 
@@ -410,7 +410,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
     /**
      * Use composer create-project to create a new local copy of the source project.
      */
-    protected function createFromSourceProject($source, $target, $stability = '', $composer_repository = '', $template_git_url = '')
+    protected function createFromSourceProject($source, $target, $stability = '', $template_repository = '')
     {
         $source_project = $this->sourceProjectFromSource($source);
 
@@ -429,12 +429,14 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
 
         $repository = '';
 
-        if ($composer_repository) {
-            $repository = ' --repository=' . $composer_repository;
-        }
-
-        if ($template_git_url) {
-            $repository = ' --repository="{\"url\": \"' . $template_git_url . '\", \"type\": \"vcs\"}"';
+        if ($template_repository) {
+            if (substr($template_repository, -4) === '.git') {
+                // It's a git repository.
+                $repository = ' --repository="{\"url\": \"' . $template_repository . '\", \"type\": \"vcs\"}"';
+            }
+            else {
+                $repository = ' --repository=' . $template_repository;
+            }
         }
 
         $this->passthru("composer create-project --working-dir=$tmpsitedir $repository $source $target -n $stability_flag");

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -388,7 +388,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
             return $this->useExistingSourceDirectory($source, $options['preserve-local-repository']);
         }
         else {
-            return $this->createFromSourceProject($source, $target, $stability);
+            return $this->createFromSourceProject($source, $target, $stability, $options['composer-repository']);
         }
     }
 
@@ -410,7 +410,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
     /**
      * Use composer create-project to create a new local copy of the source project.
      */
-    protected function createFromSourceProject($source, $target, $stability = '')
+    protected function createFromSourceProject($source, $target, $stability = '', $composer_repository = '')
     {
         $source_project = $this->sourceProjectFromSource($source);
 
@@ -427,7 +427,13 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         // Create a working directory
         $tmpsitedir = $this->tempdir('local-site');
 
-        $this->passthru("composer create-project --working-dir=$tmpsitedir $source $target -n $stability_flag");
+        $repository = '';
+
+        if ($composer_repository) {
+            $repository = ' --repository=' . $composer_repository;
+        }
+
+        $this->passthru("composer create-project --working-dir=$tmpsitedir $repository $source $target -n $stability_flag");
         $local_site_path = "$tmpsitedir/$target";
         return $local_site_path;
     }

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -486,9 +486,9 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
             $templateDir = $this->tempdir('template-dir');
             $this->passthru("git -C $templateDir clone $source --depth 1 .");
             $composer_json_contents = file_get_contents($templateDir . '/composer.json');
-            if (preg_match('/"name":\s"([A-Za-z0-9\-]+\/[A-Za-z0-9\-]+)"/', $composer_json_contents, $matches)) {
-                if (!empty($matches[1])) {
-                    $items['source'] = $matches[1];
+            if ($contents = json_decode($composer_json_contents)) {
+                if (!empty($contents->name)) {
+                    $items['source'] = $contents->name;
                 }
             }
         }

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -412,7 +412,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
      */
     protected function createFromSourceProject($source, $target, $stability = '', $template_repository = '')
     {
-        $source_project = $this->sourceProjectFromSource($source);
+        $source_project = $source;
 
         $this->log()->notice('Creating project and resolving dependencies.');
 
@@ -438,8 +438,15 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
                 $repository = ' --repository=' . $template_repository;
             }
         }
+        else {
+            $items = $this->getSourceAndTemplateFromSource($source);
+            $source_project = $items['source'];
+            if (!empty($items['template-repository'])) {
+                $repository = ' --repository="' . $items['template-repository'] . '"';
+            }
+        }
 
-        $this->passthru("composer create-project --working-dir=$tmpsitedir $repository $source $target -n $stability_flag");
+        $this->passthru("composer create-project --working-dir=$tmpsitedir $repository $source_project $target -n $stability_flag");
         $local_site_path = "$tmpsitedir/$target";
         return $local_site_path;
     }
@@ -453,6 +460,39 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
     protected function sourceProjectFromSource($source)
     {
         return preg_replace('/:.*/', '', $source);
+    }
+
+    /**
+     * Given a source:
+     *   If it's a composer repository such as:
+     *     pantheon-systems/example-drops-8-composer:dev-1.x
+     *   Return the full source in $items array: pantheon-systems/example-drops-8-composer:dev-1.x
+     *
+     *   If it's a git repo such as:
+     *     git@github.com:pantheon-systems/example-drops-8.git
+     *   Return the template-repository in json format as expected by composer create-project
+     *     and the source from the package name in the composer.json file.
+     */
+    protected function getSourceAndTemplateFromSource($source) {
+        $items = [
+            'source' => '',
+            'template-repository' => '',
+        ];
+        if (preg_match('/^[A-Za-z0-9\-]*\/[A-Za-z0-9\-]*:?[A-Za-z0-9\-]*$/', $source)) {
+            $items['source'] = $source;
+        }
+        else {
+            $items['template-repository'] = '{\"url\": \"' . $source . '\", \"type\": \"vcs\"}';
+            $templateDir = $this->tempdir('template-dir');
+            $this->passthru("git -C $templateDir clone $source --depth 1 .");
+            $composer_json_contents = file_get_contents($templateDir . '/composer.json');
+            if (preg_match('/"name":\s"([A-Za-z0-9\-]+\/[A-Za-z0-9\-]+)"/', $composer_json_contents, $matches)) {
+                if (!empty($matches[1])) {
+                    $items['source'] = $matches[1];
+                }
+            }
+        }
+        return $items;
     }
 
     /**

--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -195,6 +195,7 @@ class ProjectCreateCommand extends BuildToolsBase
      * @option keep If given, clone a local copy of the project.
      * @option env Add extra environment variables to the CI environment. For example, --env='key=value' --env='another=v2'.
      * @option composer-repository Composer repository if package is hosted on a private registry.
+     * @option template-git-url Git url to template package (if no available as composer package).
 
      */
     public function createProject(
@@ -220,6 +221,7 @@ class ProjectCreateCommand extends BuildToolsBase
             'visibility' => 'public',
             'region' => '',
             'composer-repository' => '',
+            'template-git-url' => '',
         ])
     {
         $this->warnAboutOldPhp();

--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -194,8 +194,7 @@ class ProjectCreateCommand extends BuildToolsBase
      * @option preserve-local-repository If given, use the repository in the existing source directory. Otherwise, use composer create-project to create a new local copy of the source project.
      * @option keep If given, clone a local copy of the project.
      * @option env Add extra environment variables to the CI environment. For example, --env='key=value' --env='another=v2'.
-     * @option composer-repository Composer repository if package is hosted on a private registry.
-     * @option template-git-url Git url to template package (if no available as composer package).
+     * @option template-repository Composer repository if package is hosted on a private registry or url to git.
 
      */
     public function createProject(
@@ -220,8 +219,7 @@ class ProjectCreateCommand extends BuildToolsBase
             'git' => 'github',
             'visibility' => 'public',
             'region' => '',
-            'composer-repository' => '',
-            'template-git-url' => '',
+            'template-repository' => '',
         ])
     {
         $this->warnAboutOldPhp();

--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -194,6 +194,7 @@ class ProjectCreateCommand extends BuildToolsBase
      * @option preserve-local-repository If given, use the repository in the existing source directory. Otherwise, use composer create-project to create a new local copy of the source project.
      * @option keep If given, clone a local copy of the project.
      * @option env Add extra environment variables to the CI environment. For example, --env='key=value' --env='another=v2'.
+     * @option composer-repository Composer repository if package is hosted on a private registry.
 
      */
     public function createProject(
@@ -218,6 +219,7 @@ class ProjectCreateCommand extends BuildToolsBase
             'git' => 'github',
             'visibility' => 'public',
             'region' => '',
+            'composer-repository' => '',
         ])
     {
         $this->warnAboutOldPhp();

--- a/src/ServiceProviders/CIProviders/CircleCI/CircleCIProvider.php
+++ b/src/ServiceProviders/CIProviders/CircleCI/CircleCIProvider.php
@@ -156,7 +156,6 @@ class CircleCIProvider extends BaseCIProvider implements CIProvider, LoggerAware
 
     public function startTesting(CIState $ci_env)
     {
-        sleep(10);
         $circle_url = $this->apiUrl($ci_env);
         $this->circleCIAPI([], "$circle_url/follow");
     }

--- a/src/ServiceProviders/CIProviders/CircleCI/CircleCIProvider.php
+++ b/src/ServiceProviders/CIProviders/CircleCI/CircleCIProvider.php
@@ -156,6 +156,7 @@ class CircleCIProvider extends BaseCIProvider implements CIProvider, LoggerAware
 
     public function startTesting(CIState $ci_env)
     {
+        sleep(10);
         $circle_url = $this->apiUrl($ci_env);
         $this->circleCIAPI([], "$circle_url/follow");
     }


### PR DESCRIPTION
# Private composer repository.

To use a private repository, define the auth string like this:

```
export TERMINUS_BUILD_TOOLS_COMPOSER_AUTH=json_encoded_string
```

or in .terminus/config.yml as described at https://github.com/pantheon-systems/terminus-build-tools-plugin/blob/main/src/Utility/Config.php#L21

Then, in the build:project:create command, pass a composer-repository option like this:

```
terminus build:project:create --template-repository="https://repo.packagist.com/kporras07" kporras07/example-drops-8-test my-project
```

# Git repository (no composer repository)

To use a git repository, use the terminus command like this:

```
terminus build:project:create --template-repository="git@github.com:kporras07/myrepo.git" kporras07/myrepo-template my-project
```

The package name in the composer.json file into the template repo should be "kporras07/myrepo-template". If kporras07/myrepo is a private repo, you should have access to it in your current terminal.

You can also use it as the following shorthand:

```
terminus build:project:create git@github.com:kporras07/example-drops-8-test.git  buildtoolsd807148
```

During the project creation, the repo will be cloned to gather the right package name from the composer.json file.