### PR TITLE
Add ci from other repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Additional options are available to further customize the `build:project:create`
  | --visibility          | The visibility of the project. Defaults to "public". Use "public" or "private" for GitHub and "public", "private", or "internal" for GitLab |
  | --region              | The region to create the site in. See [the Pantheon regions documentation](https://pantheon.io/docs/regions#create-a-new-site-in-a-specific-region-using-terminus) for details. |
  | --template-repository | Private composer repository to download template or git url if using the expanded version when no composer repository. |
+ | --ci-template | Git repo that contains the CI scripts that will be copied if there is no ci in the source project. |
  
 See `terminus help build:project:create` for more information.
 

--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,8 @@
     },
     "scripts": {
         "unit-test": "./vendor/bin/phpunit --bootstrap ./vendor/autoload.php tests/*"
+    },
+    "require": {
+        "consolidation/version-tool": "^0.1.9"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,12 +1,65 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "hash": "889539302c0b373864d7faae3e44e243",
-    "content-hash": "305b41305ca3690682e56c2e77999195",
-    "packages": [],
+    "content-hash": "afe05f1f8422e144dbc8a5f1098dad40",
+    "packages": [
+        {
+            "name": "consolidation/version-tool",
+            "version": "0.1.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/consolidation/version-tool.git",
+                "reference": "46939a0cfca5d1e63d1e48f3fbe808c73dde04fd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/consolidation/version-tool/zipball/46939a0cfca5d1e63d1e48f3fbe808c73dde04fd",
+                "reference": "46939a0cfca5d1e63d1e48f3fbe808c73dde04fd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "consolidation/robo": "^1.3|^2",
+                "g1a/composer-test-scenarios": "^2",
+                "knplabs/github-api": "^2.7",
+                "php-http/guzzle6-adapter": "^1.1",
+                "phpunit/phpunit": "^6",
+                "satooshi/php-coveralls": "^2",
+                "squizlabs/php_codesniffer": "^2.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "VersionTool\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Anderson",
+                    "email": "greg.1.anderson@greenknowe.org"
+                }
+            ],
+            "description": "Template project for PHP libraries.",
+            "support": {
+                "source": "https://github.com/consolidation/version-tool/tree/0.1.9"
+            },
+            "time": "2020-05-23T01:04:16+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
@@ -60,7 +113,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -114,7 +167,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-09-11 18:02:19"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -159,7 +212,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-08 06:39:58"
+            "time": "2017-08-08T06:39:58+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -206,7 +259,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-06-03 08:32:36"
+            "time": "2017-06-03T08:32:36+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -269,7 +322,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-08-05 17:53:17"
+            "time": "2018-08-05T17:53:17+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -331,7 +384,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -378,7 +431,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-27 13:52:08"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -419,7 +472,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -468,7 +521,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26 11:10:40"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -517,7 +570,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-12-04 08:55:13"
+            "time": "2017-12-04T08:55:13+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -589,7 +642,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-06-21 08:07:12"
+            "time": "2017-06-21T08:07:12+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -646,7 +699,7 @@
                 "xunit"
             ],
             "abandoned": true,
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -710,7 +763,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29 09:50:25"
+            "time": "2017-01-29T09:50:25+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -762,7 +815,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2017-05-22 07:24:03"
+            "time": "2017-05-22T07:24:03+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -812,7 +865,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-08-18T05:49:44+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -879,7 +932,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-06-17T09:04:28+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -930,7 +983,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -983,7 +1036,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-10-03 07:41:43"
+            "time": "2016-10-03T07:41:43+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1018,7 +1071,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1076,7 +1129,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-02-06 07:57:58"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -1135,7 +1188,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-03-25 07:48:46"
+            "time": "2019-03-25T07:48:46+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1186,7 +1239,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-12-25 11:19:39"
+            "time": "2018-12-25T11:19:39+00:00"
         }
     ],
     "aliases": [],
@@ -1195,5 +1248,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.1.0"
 }

--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -260,7 +260,7 @@ class ProjectCreateCommand extends BuildToolsBase
             'visibility' => 'public',
             'region' => '',
             'template-repository' => '',
-            'ci-template' => 'git@github.com:kporras07/tbt-ci-integrations.git',
+            'ci-template' => 'git@github.com:pantheon-systems/tbt-ci-integrations.git',
         ])
     {
         $this->warnAboutOldPhp();

--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -170,8 +170,8 @@ class ProjectCreateCommand extends BuildToolsBase
         $ciTemplateDir = $this->tempdir('ci-template-dir');
         $this->passthru("git -C $ciTemplateDir clone $repo --depth 1 .");
 
-        $this->passthru("cp -r $ciTemplateDir/$cms_version/.ci $created_folder/");
-        $this->passthru("cp -r $ciTemplateDir/$cms_version/providers/$short_name/.* $created_folder/");
+        $this->passthru("cp -r $ciTemplateDir/$cms_version/.ci $created_folder");
+        $this->passthru("cp -r $ciTemplateDir/$cms_version/providers/$short_name/. $created_folder");
     }
 
     /**

--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -143,12 +143,10 @@ class ProjectCreateCommand extends BuildToolsBase
     /**
      * Copy CI files from the given/default repo.
      */
-    public function copyCiFiles($ci_provider, $created_folder, $cms_version, $ci_template = '') {
+    public function copyCiFiles($ci_provider, $created_folder, $cms_version, $ci_template) {
         $fs = new Filesystem();
         $service_name = $ci_provider->getServiceName();
-        if (!$ci_template) {
-            $ci_template = 'git@github.com:kporras07/tbt-ci-integrations.git';
-        }
+
         $ciTemplateDir = $this->tempdir('ci-template-dir');
         $this->passthru("git -C $ciTemplateDir clone $ci_template --depth 1 .");
 
@@ -262,7 +260,7 @@ class ProjectCreateCommand extends BuildToolsBase
             'visibility' => 'public',
             'region' => '',
             'template-repository' => '',
-            'ci-template' => '',
+            'ci-template' => 'git@github.com:kporras07/tbt-ci-integrations.git',
         ])
     {
         $this->warnAboutOldPhp();

--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -514,8 +514,9 @@ class ProjectCreateCommand extends BuildToolsBase
             ->progressMessage('Install CMS on Pantheon site {site}', ['site' => $site_name])
             ->addCode(
                 function ($state) use ($ci_env, $site_name, $siteDir) {
-                    // Wait for 30 seconds to allow site preparation tasks to finish.
-                    sleep(30);
+                    // Wait for workflow to finish.
+                    // @todo: Is this command working as expected?
+                    $this->passthru("terminus workflow:wait $site_name.dev 'Change database version for an environment'");
                     $siteAttributes = $ci_env->getState('site');
                     $composer_json = $this->getComposerJson($siteDir);
 

--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -144,6 +144,7 @@ class ProjectCreateCommand extends BuildToolsBase
      * Copy CI files from the given/default repo.
      */
     public function copyCiFiles($ci_provider, $created_folder, $cms_version = 'd8', $repo = '') {
+        $fs = new Filesystem();
         $service_name = $ci_provider->getServiceName();
         if (!$repo) {
             $repo = 'git@github.com:kporras07/tbt-ci-integrations.git';
@@ -151,11 +152,11 @@ class ProjectCreateCommand extends BuildToolsBase
         $ciTemplateDir = $this->tempdir('ci-template-dir');
         $this->passthru("git -C $ciTemplateDir clone $repo --depth 1 .");
 
-        $this->passthru("cp -r $ciTemplateDir/$cms_version/.ci $created_folder");
-        $this->passthru("cp -r $ciTemplateDir/$cms_version/providers/$service_name/. $created_folder");
+        $fs->mirror("$ciTemplateDir/$cms_version/.ci", "$created_folder/.ci");
+        $fs->mirror("$ciTemplateDir/$cms_version/providers/$service_name/.", $created_folder);
 
         if (!is_dir("$created_folder/tests") && is_dir("$ciTemplateDir/$cms_version/tests")) {
-            $this->passthru("cp -r $ciTemplateDir/$cms_version/tests $created_folder");
+            $fs->mirror("$ciTemplateDir/$cms_version/tests", "$created_folder/tests");
         }
 
         $composer_json = $this->getComposerJson($created_folder);
@@ -173,11 +174,11 @@ class ProjectCreateCommand extends BuildToolsBase
             }
             file_put_contents("$created_folder/composer.json", json_encode($composer_json, JSON_PRETTY_PRINT));
         }
-        $this->passthru("mkdir $created_folder/web/modules/custom");
-        $this->passthru("touch $created_folder/web/modules/custom/.gitkeep");
+        $fs->mkdir("$created_folder/web/modules/custom");
+        $fs->touch("$created_folder/web/modules/custom/.gitkeep");
 
-        $this->passthru("mkdir $created_folder/web/themes/custom");
-        $this->passthru("touch $created_folder/web/themes/custom/.gitkeep");
+        $fs->mkdir("$created_folder/web/themes/custom");
+        $fs->touch("$created_folder/web/themes/custom/.gitkeep");
     }
 
     /**

--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -501,7 +501,7 @@ class ProjectCreateCommand extends BuildToolsBase
                     }
                     list($site, $env) = $this->getSiteEnv("{$site_name}.dev");
                     // Wait for workflow to finish.
-                    $this->waitForWorkflow($prePushTime, $site, $env, 'Change database version for an environment');
+                    $this->waitForWorkflow($prePushTime, $site, $env, 'Change database version for an environment', null, 3);
                     $siteAttributes = $ci_env->getState('site');
                     $composer_json = $this->getComposerJson($siteDir);
 

--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Pantheon\TerminusBuildTools\Utility\Config as Config_Utility;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use VersionTool\VersionTool;
 
 /**
  * Project Create Command
@@ -319,8 +320,18 @@ class ProjectCreateCommand extends BuildToolsBase
         $builder = $this->collectionBuilder();
 
         if (!file_exists($siteDir . '/.ci')) {
-            // @todo: Define cms_version (currently hardcoded to d9).
-            $this->copyCiFiles($this->ci_provider, $siteDir);
+            $version_info = new VersionTool();
+            $info = $version_info->info($siteDir);
+            $app = $info->application();
+            $cms_version = 'd';
+            if ($app !== 'Drupal') {
+                $cms_version = 'wp';
+            }
+            else {
+                $version = $info->version();
+                $cms_version .= substr($version, 0, 1);
+            }
+            $this->copyCiFiles($this->ci_provider, $siteDir, $cms_version);
         }
 
         // $builder->setStateValue('ci-env', $ci_env)

--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -141,30 +141,10 @@ class ProjectCreateCommand extends BuildToolsBase
     }
 
     /**
-     * Get CI short name based on the CI provider.
-     */
-    public function getCiShortName($ci_provider) {
-        $reflect = new \ReflectionClass($ci_provider);
-        switch ($reflect->getShortName()) {
-            case 'CircleCIProvider':
-                return 'circleci';
-
-            case 'GitLabCIProvider':
-                return 'gitlabci';
-
-            case 'BitbucketPipelinesProvider':
-                return 'bitbucket';
-
-            case 'GithubActionsProvider':
-                return 'github';
-        }
-    }
-
-    /**
      * Copy CI files from the given/default repo.
      */
     public function copyCiFiles($ci_provider, $created_folder, $cms_version = 'd8', $repo = '') {
-        $short_name = $this->getCiShortName($ci_provider);
+        $service_name = $ci_provider->getServiceName();
         if (!$repo) {
             $repo = 'git@github.com:kporras07/tbt-ci-integrations.git';
         }
@@ -172,7 +152,7 @@ class ProjectCreateCommand extends BuildToolsBase
         $this->passthru("git -C $ciTemplateDir clone $repo --depth 1 .");
 
         $this->passthru("cp -r $ciTemplateDir/$cms_version/.ci $created_folder");
-        $this->passthru("cp -r $ciTemplateDir/$cms_version/providers/$short_name/. $created_folder");
+        $this->passthru("cp -r $ciTemplateDir/$cms_version/providers/$service_name/. $created_folder");
 
         if (!is_dir("$created_folder/tests") && is_dir("$ciTemplateDir/$cms_version/tests")) {
             $this->passthru("cp -r $ciTemplateDir/$cms_version/tests $created_folder");

--- a/src/ServiceProviders/CIProviders/CircleCI/CircleCIProvider.php
+++ b/src/ServiceProviders/CIProviders/CircleCI/CircleCIProvider.php
@@ -156,6 +156,8 @@ class CircleCIProvider extends BaseCIProvider implements CIProvider, LoggerAware
 
     public function startTesting(CIState $ci_env)
     {
+        // Wait for 5 seconds to ensure the branch has reached CircleCI so that follow action work as expected.
+        sleep(5);
         $circle_url = $this->apiUrl($ci_env);
         $this->circleCIAPI([], "$circle_url/follow");
     }


### PR DESCRIPTION
This PR allows you to create sites using templates that don't have CI in them (e.g. pantheon-upstreams/drupal-project). By default, it uses pantheon-systems/tbt-ci-integrations but it could be overriden using --ci-template option.

Example command:
```
terminus build:project:create git@github.com:pantheon-upstreams/drupal-project.git <project_name> --stability=dev
```