### PR TITLE
CMS-254: Make Drupal 9 discoverable on build tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ It is recommended that you use one of the provided example projects as a templat
 The default template repositories are each assigned an abbreviation, as shown below:
 
 - [WordPress](https://github.com/pantheon-systems/example-wordpress-composer): `wp`
+- [Drupal 9](https://github.com/pantheon-upstreams/drupal-project): `d9`
 - [Drupal 8](https://github.com/pantheon-systems/example-drops-8-composer): `d8`
 - [Drupal 7](https://github.com/pantheon-systems/example-drops-7-composer): `d7`
 
@@ -479,6 +480,7 @@ Run `terminus list build` for a complete list of available commands. Use `termin
 In addition to the Terminus Build Tools Plugin, Pantheon maintains template repositories for:
 
 - [WordPress](https://github.com/pantheon-systems/example-wordpress-composer)
+- [Drupal 9](https://github.com/pantheon-upstreams/drupal-project)
 - [Drupal 8](https://github.com/pantheon-systems/example-drops-8-composer)
 - [Drupal 7](https://github.com/pantheon-systems/example-drops-7-composer)
 

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -321,6 +321,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         // pantheon-systems is assumed.
         //
         $aliases = [
+            'git@github.com:pantheon-upstreams/drupal-project.git' => ['d9', 'drops-9'],
             'example-drops-8-composer' => ['d8', 'drops-8'],
             'example-drops-7-composer' => ['d7', 'drops-7'],
             'example-wordpress-composer' => ['wp', 'wordpress'],
@@ -423,6 +424,11 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         }
         // Pass in --stability to `composer create-project` if user requested it.
         $stability_flag = empty($stability) ? '' : "--stability $stability";
+
+        if ($source === 'git@github.com:pantheon-upstreams/drupal-project.git' && empty($stability_flag)) {
+            // This is not published in packagist so it needs dev stability.
+            $stability_flag = '--stability dev';
+        }
 
         // Create a working directory
         $tmpsitedir = $this->tempdir('local-site');


### PR DESCRIPTION
This PR allows using "d9" as source on project create.

I'll also create a docs PR for this.