### PR TITLE
Get right install and composer require commands based on the app.

### DIFF
--- a/.circleci/set-up-globals.sh
+++ b/.circleci/set-up-globals.sh
@@ -18,7 +18,7 @@ source $BASH_ENV
 set -ex
 
 cd ~/terminus_build_tools_plugin
-composer install
+composer install --no-dev
 mkdir -p $HOME/.terminus/plugins
 ln -s $(pwd) $HOME/.terminus/plugins
 terminus list -n build

--- a/.circleci/set-up-globals.sh
+++ b/.circleci/set-up-globals.sh
@@ -18,6 +18,7 @@ source $BASH_ENV
 set -ex
 
 cd ~/terminus_build_tools_plugin
+composer install
 mkdir -p $HOME/.terminus/plugins
 ln -s $(pwd) $HOME/.terminus/plugins
 terminus list -n build

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "consolidation/version-tool",
-            "version": "0.1.9",
+            "version": "0.1.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/version-tool.git",
-                "reference": "46939a0cfca5d1e63d1e48f3fbe808c73dde04fd"
+                "reference": "8a097b8fb5192c032b1d61dfadc9c44789af53d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/version-tool/zipball/46939a0cfca5d1e63d1e48f3fbe808c73dde04fd",
-                "reference": "46939a0cfca5d1e63d1e48f3fbe808c73dde04fd",
+                "url": "https://api.github.com/repos/consolidation/version-tool/zipball/8a097b8fb5192c032b1d61dfadc9c44789af53d4",
+                "reference": "8a097b8fb5192c032b1d61dfadc9c44789af53d4",
                 "shasum": ""
             },
             "require": {
@@ -35,7 +35,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-main": "1.x-dev"
                 }
             },
             "autoload": {
@@ -55,9 +55,9 @@
             ],
             "description": "Template project for PHP libraries.",
             "support": {
-                "source": "https://github.com/consolidation/version-tool/tree/0.1.9"
+                "source": "https://github.com/consolidation/version-tool/tree/0.1.10"
             },
-            "time": "2020-05-23T01:04:16+00:00"
+            "time": "2021-10-01T19:12:14+00:00"
         }
     ],
     "packages-dev": [
@@ -373,8 +373,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sb@sebastian-bergmann.de"
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
                 }
             ],
             "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
@@ -421,8 +421,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sb@sebastian-bergmann.de"
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
                 }
             ],
             "description": "FilterIterator implementation that filters files based on a list of suffixes.",
@@ -463,8 +463,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Simple template engine.",
@@ -512,8 +512,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sb@sebastian-bergmann.de"
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
                 }
             ],
             "description": "Utility class for timing",
@@ -570,6 +570,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2017-12-04T08:55:13+00:00"
         },
         {
@@ -631,8 +632,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "The PHP Unit Testing framework.",
@@ -1065,8 +1066,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
@@ -1195,12 +1196,12 @@
             "version": "1.4.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
+                "url": "https://github.com/webmozarts/assert.git",
                 "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
                 "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
                 "shasum": ""
             },

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -618,9 +618,11 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
             'account-pass' => '',
             'site-mail' => '',
             'site-name' => ''
-        ])
+        ],
+        $app = 'Drupal'
+        )
     {
-        $command_template = $this->getInstallCommandTemplate($composer_json);
+        $command_template = $this->getInstallCommandTemplate($composer_json, $app);
         return $this->runCommandTemplateOnRemoteEnv($site_env_id, $command_template, "Install site", $site_install_options);
     }
 
@@ -729,15 +731,18 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
     /**
      * Determine the command to use to install the site.
      */
-    protected function getInstallCommandTemplate($composer_json)
+    protected function getInstallCommandTemplate($composer_json, $app)
     {
         if (isset($composer_json['extra']['build-env']['install-cms'])) {
             return $composer_json['extra']['build-env']['install-cms'];
         }
-        // TODO: Select a different default template based on the cms type (Drupal or WordPress).
-        $defaultTemplate = 'drush site-install --yes --account-mail={account-mail} --account-name={account-name} --account-pass={account-pass} --site-mail={site-mail} --site-name={site-name}';
-
-        return $defaultTemplate;
+        if ($app === 'Wordpress') {
+            return [
+                'wp core install --title={site-name} --url={site-url} --admin_user={account-name} --admin_email={account-mail} --admin_password={account-pass}',
+                'wp option update permalink_structure "/%postname%/"',
+            ];
+        }
+        return 'drush site-install --yes --account-mail={account-mail} --account-name={account-name} --account-pass={account-pass} --site-mail={site-mail} --site-name={site-name}';
     }
 
     /**

--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -333,10 +333,11 @@ class ProjectCreateCommand extends BuildToolsBase
 
         $builder = $this->collectionBuilder();
 
+        $version_info = new VersionTool();
+        $info = $version_info->info($siteDir);
+        $app = $info->application();
+
         if (!file_exists($siteDir . '/.ci')) {
-            $version_info = new VersionTool();
-            $info = $version_info->info($siteDir);
-            $app = $info->application();
             $cms_version = 'd';
             if ($app !== 'Drupal') {
                 $cms_version = 'wp';
@@ -348,9 +349,18 @@ class ProjectCreateCommand extends BuildToolsBase
             $this->copyCiFiles($this->ci_provider, $siteDir, $cms_version, $ci_template);
 
             // If folder does not exists, assume we need to install composer deps.
-            exec("composer --working-dir=$siteDir require --dev drupal/coder dealerdirect/phpcodesniffer-composer-installer squizlabs/php_codesniffer phpunit/phpunit");
-            exec("composer --working-dir=$siteDir require --dev behat/behat behat/mink behat/mink-extension dmore/behat-chrome-extension drupal/drupal-extension drupal/drupal-driver genesis/behat-fail-aid jcalderonzumba/mink-phantomjs-driver mikey179/vfsstream symfony/css-selector");
-            exec("composer --working-dir=$siteDir require drush-ops/behat-drush-endpoint");
+            // Require basic testing general packages.
+            exec("composer --working-dir=$siteDir require --dev dealerdirect/phpcodesniffer-composer-installer squizlabs/php_codesniffer phpunit/phpunit");
+            // Require behat related general packages.
+            exec("composer --working-dir=$siteDir require --dev behat/behat behat/mink behat/mink-extension dmore/behat-chrome-extension genesis/behat-fail-aid jcalderonzumba/mink-phantomjs-driver mikey179/vfsstream symfony/css-selector");
+
+            // Install packages depending on the application.
+            if ($app === 'Drupal') {
+                exec("composer --working-dir=$siteDir require --dev drupal/coder drupal/drupal-extension drupal/drupal-driver");
+                exec("composer --working-dir=$siteDir require drush-ops/behat-drush-endpoint");
+            } elseif ($app === 'WordPress') {
+                exec("composer --working-dir=$siteDir require --dev paulgibbs/behat-wordpress-extension");
+            }
         }
         $prePushTime = 0;
 
@@ -433,6 +443,10 @@ class ProjectCreateCommand extends BuildToolsBase
                     if (file_exists("$siteDir/web/themes/custom/.gitkeep")) {
                         $this->passthru("git -C $siteDir add -f web/themes/custom/.gitkeep");
                     }
+                    // This file may be in the repo but ignored (e.g. https://github.com/pantheon-upstreams/wordpress-project).
+                    if (file_exists("$siteDir/pantheon.upstream.yml")) {
+                        $this->passthru("git -C $siteDir add -f pantheon.upstream.yml");
+                    }
                     $headCommit = $this->initialCommit($siteDir, $source);
                 })
 
@@ -504,7 +518,7 @@ class ProjectCreateCommand extends BuildToolsBase
             // Note that this also commits the configuration to the repository.
             ->progressMessage('Install CMS on Pantheon site {site}', ['site' => $site_name])
             ->addCode(
-                function ($state) use ($ci_env, $site_name, $siteDir, &$prePushTime) {
+                function ($state) use ($ci_env, $site_name, $siteDir, &$prePushTime, $app) {
                     if (!$prePushTime) {
                         $prePushTime = time() - 1800;
                     }
@@ -523,7 +537,7 @@ class ProjectCreateCommand extends BuildToolsBase
                         'site-name' => $siteAttributes->testSiteName(),
                         'site-url' => "https://dev-{$site_name}.pantheonsite.io"
                     ];
-                    $this->doInstallSite("{$site_name}.dev", $composer_json, $site_install_options);
+                    $this->doInstallSite("{$site_name}.dev", $composer_json, $site_install_options, $app);
 
                     // Before any tests have been configured, export the
                     // configuration set up by the installer.


### PR DESCRIPTION
This will enable terminus build tools to work properly with unofficial Wordpress upstreams with CI not included in the same repo. An example of this is https://github.com/pantheon-upstreams/wordpress-project

```
terminus build:project:create git@github.com:pantheon-upstreams/wordpress-project.git --stability=dev  mywpsite
```