### PR TITLE
CMS-294: Add .gitignore cut command and append cut line when not present in source .gitignore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,10 @@ The `build:workflow:wait` command waits for a workflow in Pantheon to complete b
  | --start          | The time to ignore workflow operations before |
  | --max            | The maximum amount of time to wait for a workflow to complete |
 
+### build:gitignore:cut
+
+The `build:gitignore:cut` command cuts your .gitignore file in the cut line. This is useful before pushing to Pantheon from a source repo.
+
 
 ## Customization
 

--- a/src/Commands/GitignoreCutCommand.php
+++ b/src/Commands/GitignoreCutCommand.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Terminus Plugin that contain a collection of commands useful during
+ * the build step on a [Pantheon](https://www.pantheon.io) site that uses
+ * a GitHub PR workflow.
+ *
+ * See README.md for usage information.
+ */
+
+namespace Pantheon\TerminusBuildTools\Commands;
+
+/**
+ * Gitignore cut Command
+ *
+ * Cut gitignore in the cut mark.
+ */
+class GitignoreCutCommand extends BuildToolsBase
+{
+
+    /**
+     * Cut gitignore in the cut mark.
+     *
+     * @command build:gitignore:cut
+     * @aliases build:gitignore-cut
+     */
+    public function gitignoreCut()
+    {
+        $gitignore_file = getcwd() . '/.gitignore';
+
+        if (file_exists($gitignore_file)) {
+            $gitignore_contents = file_get_contents($gitignore_file);
+            $gitignore_contents = preg_replace('/.*#\s?:+\s?cut\s?:+/s', '', $gitignore_contents);
+            file_put_contents($gitignore_file, $gitignore_contents);
+            $this->log()->notice('.gitignore cut done.');
+
+       }
+        else {
+            $this->log()->warning('.gitignore file not found. Nothing to do.');
+        }
+    }
+}

--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -465,8 +465,9 @@ class ProjectCreateCommand extends BuildToolsBase
                             $lines_to_add = [
                                 '# :::::::::::::::::::::: cut ::::::::::::::::::::::',
                                 '',
-                                '# Put ignore patterns for css build artifacts & c. below',
-                                '# Files below this line are ignored on the source repo and committed on Pantheon',
+                                '# Put ignore patterns for css build artifacts and similar items below.',
+                                '# Files below this line are still ignored on Pantheon.',
+                                '# Files above this line are only ignored in the source repository.',
                             ];
                             $gitignore_contents .= "\r\n" . implode("\r\n", $lines_to_add);
                             file_put_contents("$siteDir/.gitignore", $gitignore_contents);

--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -456,6 +456,30 @@ class ProjectCreateCommand extends BuildToolsBase
                     $headCommit = $this->initialCommit($siteDir, $source);
                 })
 
+            ->progressMessage('Fix .gitignore file if needed')
+            ->addCode(
+                function () use ($siteDir) {
+                    if (file_exists("$siteDir/.gitignore")) {
+                        $gitignore_contents = file_get_contents("$siteDir/.gitignore");
+                        if (preg_match('/#\s?:+\s?cut\s?:+/', $gitignore_contents) === 0) {
+                            $lines_to_add = [
+                                '# :::::::::::::::::::::: cut ::::::::::::::::::::::',
+                                '',
+                                '# Put ignore patterns for css build artifacts & c. below',
+                                '# Files below this line are ignored on the source repo and committed on Pantheon',
+                            ];
+                            $gitignore_contents .= "\r\n" . implode("\r\n", $lines_to_add);
+                            file_put_contents("$siteDir/.gitignore", $gitignore_contents);
+                            passthru("git -C {$siteDir} add .gitignore");
+                            passthru("git -C {$siteDir} commit -m 'Update .gitignore to include cut line.'");
+
+                        } else {
+                            $this->log()->notice('.gitignore already contains the cut line. Nothing to do.');
+                        }
+                    }
+                }
+            )
+
             ->progressMessage('Set up CI services')
 
             // Set up CI to test our project.


### PR DESCRIPTION
This PR adds a new command to cut on the cut mark for a gitignore file. This was handled by a composer script in d8, wp and d7 templates but we're adding it to build tools in order to be able to use it for non-standard templates.

Also, the cut mark is added to .gitignore during site creation if the source repo doesn't have it.