### PR TITLE
ignore the platform requirements for behat-wordpress-extension

### DIFF
--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -359,7 +359,7 @@ class ProjectCreateCommand extends BuildToolsBase
                 exec("composer --working-dir=$siteDir require --dev drupal/coder drupal/drupal-extension drupal/drupal-driver");
                 exec("composer --working-dir=$siteDir require drush-ops/behat-drush-endpoint");
             } elseif ($app === 'WordPress') {
-                exec("composer --working-dir=$siteDir require --dev paulgibbs/behat-wordpress-extension");
+                exec("composer --working-dir=$siteDir require --dev paulgibbs/behat-wordpress-extension --ignore-platform-reqs");
             }
         }
         $prePushTime = 0;


### PR DESCRIPTION
the wp behat extension requires php >7.2 <7.4. The only version that is compatible with our environment is 0.7.1 which just requires php >5.6.0
This extension is no longer supported but we definitely don't need an ancient version so we can ignore the php requirements to prevent other composer conflicts.

**cherry-picked from #411 