### PR TITLE
add additional wp config paths to check for

### DIFF
--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -368,6 +368,8 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
           'core/misc/drupal.js' => 'empty', // Drupal 8
           'misc/drupal.js' => 'empty-7', // Drupal 7
           'wp-config.php' => 'empty-wordpress', // WordPress
+          'wp-config-sample.php' => 'empty-wordpress', // Also WordPress
+          'wp-config-pantheon.php' => 'empty-wordpress', // Also also WordPress
         ];
 
         foreach ($upstream_map as $file => $upstream) {


### PR DESCRIPTION
This PR adds additional file paths that will identify the site as WordPress, specifically `wp-config-sample.php` and `wp-config-pantheon.php`.

Fixes #415 @3.x