### PR TITLE
Fix regex for gitlab tokens.

### DIFF
--- a/.circleci/set-up-globals.sh
+++ b/.circleci/set-up-globals.sh
@@ -20,7 +20,8 @@ set -ex
 # Update terminus temporarily.
 rm /usr/local/bin/terminus
 mkdir ~/terminus && cd ~/terminus
-curl -L https://github.com/pantheon-systems/terminus/releases/download/`curl --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | perl -nle'print $& while m#"tag_name": "\K[^"]*#g'`/terminus.phar --output terminus
+TERMINUS_RELEASE=$(curl --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | perl -nle'print $& while m#"tag_name": "\K[^"]*#g')
+curl -L https://github.com/pantheon-systems/terminus/releases/download/$TERMINUS_RELEASE/terminus.phar --output terminus
 chmod +x terminus
 ln -s ~/terminus/terminus /usr/local/bin/terminus
 terminus self:info

--- a/.circleci/set-up-globals.sh
+++ b/.circleci/set-up-globals.sh
@@ -18,12 +18,11 @@ source $BASH_ENV
 set -ex
 
 # Update terminus temporarily.
-cd /opt/terminus
-git fetch
-git checkout 3.x
-composer install
 rm /usr/local/bin/terminus
-ln -s /opt/terminus/bin/t3 /usr/local/bin/terminus
+mkdir ~/terminus && cd ~/terminus
+curl -L https://github.com/pantheon-systems/terminus/releases/download/`curl --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | perl -nle'print $& while m#"tag_name": "\K[^"]*#g'`/terminus.phar --output terminus
+chmod +x terminus
+ln -s ~/terminus/terminus /usr/local/bin/terminus
 terminus self:info
 
 terminus self:plugin:install /root/terminus_build_tools_plugin

--- a/src/API/GitLab/GitLabAPITrait.php
+++ b/src/API/GitLab/GitLabAPITrait.php
@@ -68,7 +68,7 @@ trait GitLabAPITrait
   {
     $instructions = "Please generate a GitLab personal access token by visiting the page:\n\n    https://" . $this->getGitLabUrl() . "/profile/personal_access_tokens\n\n For more information, see:\n\n    https://" . $this->getGitLabUrl() . "/help/user/profile/personal_access_tokens.md.\n\n Give it the 'api', 'read_repository', and 'write_repository' (required) scopes.";
 
-    $validation_message = 'GitLab authentication tokens should be 20-character strings containing only the letters a-z and digits (0-9). Please enter your token again.';
+    $validation_message = 'GitLab authentication tokens should be 20 or 26 characters strings containing only the letters a-z and digits (0-9). Please enter your token again.';
 
     $could_not_authorize = 'Your provided authentication token could not be used to authenticate with the GitLab service. Please re-enter your credential.';
 
@@ -77,7 +77,7 @@ trait GitLabAPITrait
     $gitlabTokenRequest = (new CredentialRequest($this->tokenKey()))
         ->setInstructions($instructions)
         ->setPrompt("Enter GitLab personal access token: ")
-        ->setValidateRegEx('#^[0-9a-zA-Z\-_]{20}$#')
+        ->setValidateRegEx('#^[0-9a-zA-Z\-_]{20,26}$#')
         ->setValidationErrorMessage($validation_message)
         ->setValidationCallbackErrorMessage($could_not_authorize)
         ->setValidateFn(


### PR DESCRIPTION
This was previously 20 characters, now it's 26 characters. I'm opening support for both in case there are old gitlab installations still on 20 characters (not even sure if this is possible though)