### PR TITLE
Fix no-git-force option parameter

### DIFF
--- a/src/Commands/EnvCreateCommand.php
+++ b/src/Commands/EnvCreateCommand.php
@@ -57,7 +57,7 @@ class EnvCreateCommand extends BuildToolsBase
         if ('dev' === $multidev) {
             $this->log()->notice('dev has been passed to the multidev option. Reverting to dev:env:push as dev is not a multidev environment.');
             // Run build:env:push.
-            $this->pushCodeToPantheon($site_env_id, $multidev, '', $env_label, $options['message'], $options['git-force']);
+            $this->pushCodeToPantheon($site_env_id, $multidev, '', $env_label, $options['message'], $options['no-git-force']);
             return;
         }
 


### PR DESCRIPTION
The correct name of the parameter is `no-git-force` but it is sending `git-force`
The parameter name in the $options array in the method parameter list:
```
$options = [
            'label' => '',
            'clone-content' => false,
            'notify' => '',
            'db-only' => false,
            'message' => '',
            'pr-id' =>  '',
            'no-git-force' =>  false,
        ])
````
And lower is an example of how it is correclty used
```
$metadata = $this->pushCodeToPantheon($site_env_id, $multidev, '', $env_label, $options['message'], $options['no-git-force']);
```