### PR TITLE
2.x Pass db-only flag intent along to the environments() create method.

### DIFF
--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -1019,12 +1019,13 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
      *
      * @param string $site_env Source site and environment.
      * @param string $multidev Name of environment to create.
+     * @param array $options Create options.
      */
-    public function create($site_env, $multidev)
+    public function create($site_env, $multidev, array $options = [])
     {
         list($site, $env) = $this->getSiteEnv($site_env, 'dev');
         $this->log()->notice("Creating multidev {env} for site {site}", ['site' => $site->getName(), 'env' => $multidev]);
-        $workflow = $site->getEnvironments()->create($multidev, $env);
+        $workflow = $site->getEnvironments()->create($multidev, $env, $options);
         while (!$workflow->checkProgress()) {
             // TODO: Add workflow progress output
         }

--- a/src/Commands/EnvCreateCommand.php
+++ b/src/Commands/EnvCreateCommand.php
@@ -89,7 +89,10 @@ class EnvCreateCommand extends BuildToolsBase
             // will not be applied unless we push our change.
             // To allow pantheon.yml to be processed, we will
             // create the multidev environment, and then push the code.
-            $this->create($site_env_id, $multidev);
+            $this->create($site_env_id, $multidev, [
+              'no-db' => !$options['db-only'],
+              'no-files' => $options['db-only'],
+            ]);
             $doNotify = true;
         }
 
@@ -100,7 +103,10 @@ class EnvCreateCommand extends BuildToolsBase
             // If the environment is created after the branch is pushed,
             // then there is never a race condition -- the new env is
             // created with the correct files from the specified branch.
-            $this->create($site_env_id, $multidev);
+            $this->create($site_env_id, $multidev, [
+              'no-db' => !$options['db-only'],
+              'no-files' => $options['db-only'],
+            ]);
             $doNotify = true;
         }
 


### PR DESCRIPTION
This allows the`--db-only` flag to work correctly when creating a new environment.

Solves #455 for 2.x branch. If this is acceptible, I can re-roll this for the 3.x branch as well.