### PR TITLE
Make all WordPress check in lower case.

### DIFF
--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -760,7 +760,7 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         if (isset($composer_json['extra']['build-env']['install-cms'])) {
             return $composer_json['extra']['build-env']['install-cms'];
         }
-        if ($app === 'Wordpress') {
+        if (strtolower($app) === 'wordpress') {
             return [
                 'wp core install --title={site-name} --url={site-url} --admin_user={account-name} --admin_email={account-mail} --admin_password={account-pass}',
                 'wp option update permalink_structure "/%postname%/"',

--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -362,7 +362,7 @@ class ProjectCreateCommand extends BuildToolsBase
                 exec("composer --working-dir=$siteDir require --no-update --dev drupal/coder drupal/drupal-extension drupal/drupal-driver");
                 exec("composer --working-dir=$siteDir require --no-update drush-ops/behat-drush-endpoint");
                 exec("composer --working-dir=$siteDir require --no-update pantheon-systems/quicksilver-pushback");
-            } elseif ($app === 'WordPress') {
+            } elseif (strtolower($app) === 'wordpress') {
                 exec("composer --working-dir=$siteDir require --no-update --dev paulgibbs/behat-wordpress-extension --ignore-platform-reqs");
             }
             exec("composer --working-dir=$siteDir update");


### PR DESCRIPTION
Making all the WordPress checks in lower case because [version-tool](https://github.com/consolidation/version-tool/blob/main/src/Inspectors/WordPressInspector.php#L44) set "WordPress" and in the plugin it checks for different cases.