### PR TITLE
Fix deprecated trim() messages when using PHP 8.1

### DIFF
--- a/src/Credentials/CredentialManager.php
+++ b/src/Credentials/CredentialManager.php
@@ -125,7 +125,7 @@ class CredentialManager implements CredentialProviderInterface
             return;
         }
         $credential = $this->cache->get($key);
-        $credential = trim($credential);
+        $credential = trim($credential ?? '');
         $this->storeTransient($id, $credential);
 
         return $credential;
@@ -136,7 +136,7 @@ class CredentialManager implements CredentialProviderInterface
      */
     public function store($id, $credential)
     {
-        $credential = trim($credential);
+        $credential = trim($credential ?? '');
         $this->storeTransient($id, $credential);
         $key = $this->credentialKey($id);
         if (!empty($key)) {
@@ -207,7 +207,7 @@ class CredentialManager implements CredentialProviderInterface
         while (true) {
             $io->write("\n\n");
             $credential = $io->askHidden($prompt);
-            $credential = trim($credential);
+            $credential = trim($credential ?? '');
 
             // If the credential validates, set it and return. Otherwise
             // we'll ask again.


### PR DESCRIPTION
Running `build:project:create` using PHP 8.1, shows deprecated messages like:

` PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in /Users/vincentmassaro/.terminus/terminus-dependencies-4f7bf5e1bb/vendor/pantheon-systems/terminus-build-tools-plugin/src/Credentials/CredentialManager.php on line 128`

This commit fixes these instances of `trim()` in `src/Credentials/CredentialManager.php` so it doesn't receive a null value. Thanks.