### PR TITLE
[BUGS-5353] Avoid adding json param if GET request.

### DIFF
--- a/src/ServiceProviders/CIProviders/CircleCI/CircleCIProvider.php
+++ b/src/ServiceProviders/CIProviders/CircleCI/CircleCIProvider.php
@@ -184,11 +184,14 @@ class CircleCIProvider extends BaseCIProvider implements CIProvider, LoggerAware
         ];
 
         $client = new \GuzzleHttp\Client();
-        $res = $client->request($method, $url, [
+        $request = [
             'headers' => $headers,
             'auth' => [$this->circle_token, ''],
-            'json' => $data,
-        ]);
+        ];
+        if ($method !== 'GET') {
+            $request['json'] = $data;
+        }
+        $res = $client->request($method, $url, $request);
         return $res->getStatusCode();
     }
 


### PR DESCRIPTION
Previously it was ignored, now it fails the request with 403.

Fixes #461 