### PR TITLE
Add a create-before-push and git-commit-compare options for build:env:create

### DIFF
--- a/src/Commands/EnvCreateCommand.php
+++ b/src/Commands/EnvCreateCommand.php
@@ -30,6 +30,7 @@ class EnvCreateCommand extends BuildToolsBase
      * @option message Commit message to include when committing assets to Pantheon
      * @option pr-id Post notification comment to a specific PR instead of the commit hash.
      * @option no-git-force set this flag to omit the --force flag from 'git add' and 'git push'
+     * @option create-before-push Force the environment to be created first before pushing code.
      */
     public function createBuildEnv(
         $site_env_id,
@@ -42,6 +43,7 @@ class EnvCreateCommand extends BuildToolsBase
             'message' => '',
             'pr-id' =>  '',
             'no-git-force' =>  false,
+            'create-before-push' => false,
         ])
     {
         list($site, $env) = $this->getSiteEnv($site_env_id);
@@ -78,7 +80,7 @@ class EnvCreateCommand extends BuildToolsBase
         $environmentExists = $site->getEnvironments()->has($multidev);
 
         // Check to see if we should create before pushing or after
-        $createBeforePush = $this->commitChangesFile('HEAD', 'pantheon.yml') || $this->commitChangesFile('HEAD', 'pantheon.upstream.yml');
+        $createBeforePush = $options['create-before-push'] || $this->commitChangesFile('HEAD', 'pantheon.yml') || $this->commitChangesFile('HEAD', 'pantheon.upstream.yml');
 
         if (!$environmentExists && $createBeforePush) {
             // If pantheon.yml exists, then we need to create the environment

--- a/src/Commands/EnvCreateCommand.php
+++ b/src/Commands/EnvCreateCommand.php
@@ -31,6 +31,7 @@ class EnvCreateCommand extends BuildToolsBase
      * @option pr-id Post notification comment to a specific PR instead of the commit hash.
      * @option no-git-force set this flag to omit the --force flag from 'git add' and 'git push'
      * @option create-before-push Force the environment to be created first before pushing code.
+     * @option git-commit-compare The Git commit identifier to use when checking for changes to pantheon configuraiton YAML files.
      */
     public function createBuildEnv(
         $site_env_id,
@@ -44,6 +45,7 @@ class EnvCreateCommand extends BuildToolsBase
             'pr-id' =>  '',
             'no-git-force' =>  false,
             'create-before-push' => false,
+            'git-commit-compare' => 'HEAD',
         ])
     {
         list($site, $env) = $this->getSiteEnv($site_env_id);
@@ -80,7 +82,7 @@ class EnvCreateCommand extends BuildToolsBase
         $environmentExists = $site->getEnvironments()->has($multidev);
 
         // Check to see if we should create before pushing or after
-        $createBeforePush = $options['create-before-push'] || $this->commitChangesFile('HEAD', 'pantheon.yml') || $this->commitChangesFile('HEAD', 'pantheon.upstream.yml');
+        $createBeforePush = $options['create-before-push'] || $this->commitChangesFile($options['git-commit-compare'], 'pantheon.yml') || $this->commitChangesFile($options['git-commit-compare'], 'pantheon.upstream.yml');
 
         if (!$environmentExists && $createBeforePush) {
             // If pantheon.yml exists, then we need to create the environment

--- a/src/Commands/EnvCreateCommand.php
+++ b/src/Commands/EnvCreateCommand.php
@@ -31,7 +31,7 @@ class EnvCreateCommand extends BuildToolsBase
      * @option pr-id Post notification comment to a specific PR instead of the commit hash.
      * @option no-git-force set this flag to omit the --force flag from 'git add' and 'git push'
      * @option create-before-push Force the environment to be created first before pushing code.
-     * @option git-commit-compare The Git commit identifier to use when checking for changes to pantheon configuraiton YAML files.
+     * @option git-ref-compare The Git commit identifier to use when checking for changes to pantheon configuraiton YAML files.
      */
     public function createBuildEnv(
         $site_env_id,
@@ -45,7 +45,7 @@ class EnvCreateCommand extends BuildToolsBase
             'pr-id' =>  '',
             'no-git-force' =>  false,
             'create-before-push' => false,
-            'git-commit-compare' => 'HEAD',
+            'git-ref-compare' => 'HEAD',
         ])
     {
         list($site, $env) = $this->getSiteEnv($site_env_id);
@@ -82,7 +82,7 @@ class EnvCreateCommand extends BuildToolsBase
         $environmentExists = $site->getEnvironments()->has($multidev);
 
         // Check to see if we should create before pushing or after
-        $createBeforePush = $options['create-before-push'] || $this->commitChangesFile($options['git-commit-compare'], 'pantheon.yml') || $this->commitChangesFile($options['git-commit-compare'], 'pantheon.upstream.yml');
+        $createBeforePush = $options['create-before-push'] || $this->commitChangesFile($options['git-ref-compare'], 'pantheon.yml') || $this->commitChangesFile($options['git-commit-compare'], 'pantheon.upstream.yml');
 
         if (!$environmentExists && $createBeforePush) {
             // If pantheon.yml exists, then we need to create the environment


### PR DESCRIPTION
Workflows that push code via CI tools do not always pass the commitChangesFile('HEAD', 'pantheon.yml') check because on branches, the HEAD commit may not contain the change to pantheon.yml, but a previous commit will on the same branch.