### PR TITLE
Clarify that build:env:push can't push directly to test or live

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ There are no additional command options for this command.
 
 ### build:env:push
 
-The `build:env:push` command pushes code in the current directory to an existing Pantheon site/environment.
+The `build:env:push` command pushes code in the current directory to an existing dev or multidev Pantheon site/environment.
 
 #### Command Options
 

--- a/src/Commands/EnvPushCommand.php
+++ b/src/Commands/EnvPushCommand.php
@@ -15,7 +15,7 @@ namespace Pantheon\TerminusBuildTools\Commands;
 class EnvPushCommand extends BuildToolsBase
 {
     /**
-     * Push code to a specific Pantheon site and environment that already exists.
+     * Push code to a specific Pantheon site and dev or multidev environment that already exists.
      *
      * @command build:env:push
      * @aliases build-env:push-code


### PR DESCRIPTION
This is documented in the `site_env_id` parameter, so it's only obvious if you run `terminus help build:env:push`.