### PR TITLE
fixed incorrect URL for the GitLab Personal Access Tokens page

### DIFF
--- a/src/API/GitLab/GitLabAPITrait.php
+++ b/src/API/GitLab/GitLabAPITrait.php
@@ -66,7 +66,7 @@ trait GitLabAPITrait
    */
   public function credentialRequests()
   {
-    $instructions = "Please generate a GitLab personal access token by visiting the page:\n\n    https://" . $this->getGitLabUrl() . "/profile/personal_access_tokens\n\n For more information, see:\n\n    https://" . $this->getGitLabUrl() . "/help/user/profile/personal_access_tokens.md.\n\n Give it the 'api', 'read_repository', and 'write_repository' (required) scopes.";
+    $instructions = "Please generate a GitLab personal access token by visiting the page:\n\n    https://" . $this->getGitLabUrl() . "/-/user_settings/personal_access_tokens\n\n For more information, see:\n\n    https://" . $this->getGitLabUrl() . "/help/user/profile/personal_access_tokens.md.\n\n Give it the 'api', 'read_repository', and 'write_repository' (required) scopes.";
 
     $validation_message = 'GitLab authentication tokens should be 20 or 26 characters strings containing only the letters a-z and digits (0-9). Please enter your token again.';
 


### PR DESCRIPTION
Current version points the user to an incorrect URL for the GitLab Personal Access Tokens Page. PR corrects that.