### PR TITLE
Add d10 d11

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ It is recommended that you use one of the provided example projects as a templat
 The default template repositories are each assigned an abbreviation, as shown below:
 
 - [WordPress](https://github.com/pantheon-systems/example-wordpress-composer): `wp`
+- [Drupal 11](https://github.com/pantheon-upstreams/drupal-11-composer-managed): `d11`
+- [Drupal 10](https://github.com/pantheon-upstreams/drupal-10-composer-managed): `d10`
 - [Drupal 9](https://github.com/pantheon-upstreams/drupal-composer-managed): `d9`
 - [Drupal 8](https://github.com/pantheon-systems/example-drops-8-composer): `d8`
 - [Drupal 7](https://github.com/pantheon-systems/example-drops-7-composer): `d7`

--- a/src/Commands/BuildToolsBase.php
+++ b/src/Commands/BuildToolsBase.php
@@ -321,6 +321,8 @@ class BuildToolsBase extends TerminusCommand implements SiteAwareInterface, Buil
         // pantheon-systems is assumed.
         //
         $aliases = [
+            'git@github.com:pantheon-upstreams/drupal-11-composer-managed.git' => ['d11'],
+            'git@github.com:pantheon-upstreams/drupal-10-composer-managed.git' => ['d10'],
             'git@github.com:pantheon-upstreams/drupal-composer-managed.git' => ['d9', 'drops-9'],
             'example-drops-8-composer' => ['d8', 'drops-8'],
             'example-drops-7-composer' => ['d7', 'drops-7'],

--- a/src/Commands/ProjectCreateCommand.php
+++ b/src/Commands/ProjectCreateCommand.php
@@ -368,6 +368,11 @@ class ProjectCreateCommand extends BuildToolsBase
                 $version = $info->version();
                 $cms_version .= substr($version, 0, 1);
             }
+            // Assumes that all versions of Drupal 10-19 will work with the
+            // d9 template from https://github.com/pantheon-systems/tbt-ci-templates.
+            if ($cms_version == 'd1') {
+                $cms_version = 'd9';
+            }
             $this->copyCiFiles($this->ci_provider, $siteDir, $cms_version, $ci_template);
 
             // If folder does not exists, assume we need to install composer deps.


### PR DESCRIPTION
Adds the Drupal 10 and Drupal 11 upstreams so you can run this:

```
terminus build:project:create --git=gitlab --team='My Agency Name' d10 my-site
terminus build:project:create --git=gitlab --team='My Agency Name' d11 my-site
```
The change to src/Commands/ProjectCreateCommand.php feels a little cheap, but it works for now.